### PR TITLE
[N/A] Temporary fix for provider connecting to itself bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2195,7 +2195,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2216,12 +2217,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2236,17 +2239,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2363,7 +2369,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2375,6 +2382,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2389,6 +2397,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2396,12 +2405,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2420,6 +2431,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2500,7 +2512,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2512,6 +2525,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2597,7 +2611,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2633,6 +2648,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2652,6 +2668,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2695,12 +2712,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -171,24 +171,27 @@ export class ContextListener {
 // ------------------------------------------------------------------------------------
 // Code below here initialises/manages the connection between the application and the OpenFin Desktop Agent
 
-const servicePromise = fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version}});
+let servicePromise;
 const intentListeners: IntentListener[] = [];
 const contextListeners: ContextListener[] = [];
 
-
-fin.InterApplicationBus.subscribe(IDENTITY, 'intent', (payload: Intent, uuid: string, name: string) => {
-    intentListeners.forEach((listener: IntentListener) => {
-        if (payload.intent === listener.intent) {
-            listener.handler(payload.context);
-        }
+if (fin.Window.me.uuid !== 'fdc3-service'){
+    servicePromise = fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version}});   
+    
+    fin.InterApplicationBus.subscribe(IDENTITY, 'intent', (payload: Intent, uuid: string, name: string) => {
+        intentListeners.forEach((listener: IntentListener) => {
+            if (payload.intent === listener.intent) {
+                listener.handler(payload.context);
+            }
+        });
     });
-});
-
-fin.InterApplicationBus.subscribe(IDENTITY, 'context', (payload: Context, uuid: string, name: string) => {
-    contextListeners.forEach((listener: ContextListener) => {
-        listener.handler(payload);
+    
+    fin.InterApplicationBus.subscribe(IDENTITY, 'context', (payload: Context, uuid: string, name: string) => {
+        contextListeners.forEach((listener: ContextListener) => {
+            listener.handler(payload);
+        });
     });
-});
+}
 
 /**
  * Wrapper around any objects coming back from the API.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -175,9 +175,9 @@ let servicePromise;
 const intentListeners: IntentListener[] = [];
 const contextListeners: ContextListener[] = [];
 
-if (fin.Window.me.uuid !== 'fdc3-service'){
-    servicePromise = fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version}});   
-    
+if (fin.Window.me.uuid !== 'fdc3-service') {
+    servicePromise = fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version}});
+
     fin.InterApplicationBus.subscribe(IDENTITY, 'intent', (payload: Intent, uuid: string, name: string) => {
         intentListeners.forEach((listener: IntentListener) => {
             if (payload.intent === listener.intent) {
@@ -185,7 +185,7 @@ if (fin.Window.me.uuid !== 'fdc3-service'){
             }
         });
     });
-    
+
     fin.InterApplicationBus.subscribe(IDENTITY, 'context', (payload: Context, uuid: string, name: string) => {
         contextListeners.forEach((listener: ContextListener) => {
             listener.handler(payload);

--- a/src/provider/AppDirectory.ts
+++ b/src/provider/AppDirectory.ts
@@ -13,7 +13,7 @@ export class AppDirectory {
      *
      * This URL is currently hard-coded but will eventually be defined in a place that can be controlled by the desktop owner.
      */
-    private static URL: string = 'https://app-directory.openfin.co/api/v1/apps/';
+    private static URL: string = 'http://localhost:3012/demo/app-directory.json';
 
     /**
      * If cached application list is older than this duration, the next request to fetch the list of applications

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,9 +1,9 @@
+import {Intent} from '../client';
 import {IApplication} from '../client/directory';
+import {IntentType} from '../client/intents';
 
 import {FDC3} from './FDC3';
 import {IAppMetadata} from './MetadataStore';
-import { IntentType } from '../client/intents';
-import { Intent } from '../client';
 
 console.log('the provider has landed.');
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,8 +1,9 @@
 import {IApplication} from '../client/directory';
-import * as fdc3 from '../client/index';
 
 import {FDC3} from './FDC3';
 import {IAppMetadata} from './MetadataStore';
+import { IntentType } from '../client/intents';
+import { Intent } from '../client';
 
 console.log('the provider has landed.');
 
@@ -40,7 +41,7 @@ export interface IOpenArgs {
     context?: any;  // tslint:disable-line
 }
 export interface IResolveArgs {
-    intent: fdc3.IntentType;
+    intent: IntentType;
     context?: any;  // tslint:disable-line
 }
 export interface ISelectorResultArgs {
@@ -90,7 +91,7 @@ export interface IQueuedIntent {
     /**
      * The original intent, launched by the user
      */
-    intent: fdc3.Intent;
+    intent: Intent;
 
     /**
      * UUID of the application that fired this intent


### PR DESCRIPTION
Quick PR to make the demo apps work again. Also reverted the app-directory link change so we can use the demo apps for development.

A more permanent fix will be to update the client structure to be more like layouts (i.e. separate internal, connection and main), which will avoid having to import any connection logic in the provider. This should be happening very soon, but would be hard to do if starting from a non-working state.