### PR TITLE
[N/A] JSdoc linting & .gitignore update

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,9 @@
         "plugin:import/errors",
         "plugin:react/recommended"
     ],
+    "plugins": [
+        "jsdoc"
+    ],
     "globals": {
         "fin": "readonly"
     },
@@ -60,16 +63,28 @@
         "prefer-const": "error",
         "prefer-promise-reject-errors": "error",
         "quotes": ["error", "single"],
-        "require-jsdoc": "warn",
+        "require-jsdoc": "off",
         "semi": "error",
         "space-in-parens": "error",
         "spaced-comment": "error",
-        "valid-jsdoc": ["warn", {
-            "requireReturn": false,
-            "requireReturnType": false,
-            "requireParamType": false,
-            "requireParamDescription": true,
-            "requireReturnDescription": false
-        }]
+        "jsdoc/check-examples": 1,
+        "jsdoc/check-param-names": 1,
+        "jsdoc/check-tag-names": 1,
+        "jsdoc/check-types": 1,
+        "jsdoc/newline-after-description": 0,
+        "jsdoc/no-undefined-types": 1,
+        "jsdoc/require-description": 0,
+        "jsdoc/require-description-complete-sentence": 0,
+        "jsdoc/require-example": 0,
+        "jsdoc/require-hyphen-before-param-description": 0,
+        "jsdoc/require-param": 1,
+        "jsdoc/require-param-description": 1,
+        "jsdoc/require-param-name": 0,
+        "jsdoc/require-param-type": 0,
+        "jsdoc/require-returns": 0,
+        "jsdoc/require-returns-check": 0,
+        "jsdoc/require-returns-description": 1,
+        "jsdoc/require-returns-type": 0,
+        "jsdoc/valid-types": 1
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
+.vscode
 .DS_STORE
 npm-debug.log
 openfin-fdc3-*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -5445,6 +5445,12 @@
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.5.4.tgz",
+      "integrity": "sha512-0h7W6Y1Kb6zKQMJqdX41C5qf9ITCVIsD2qP2RaqDF3GFkXFrmuAuv5zUOuo19YzyC9scjBNpqzuaRQ2Sy5pxMQ==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -6487,6 +6493,17 @@
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-4.7.0.tgz",
+      "integrity": "sha512-ghsgfi4j8rwnCWX/jSDHdyvqt4KzEnuXa0kYXfDhTQvd/ZDt4LNBfBC9ZVXc0ApqZDI8TL3L10og2er2s4O/7g==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.5.4",
+        "jsdoctypeparser": "^2.0.0-alpha-8",
+        "lodash": "^4.17.11"
       }
     },
     "eslint-plugin-react": {
@@ -10441,6 +10458,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdoctypeparser": {
+      "version": "2.0.0-alpha-8",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-2.0.0-alpha-8.tgz",
+      "integrity": "sha1-uvE3+44qVYgQrc8Z0tKi9oDpCl8=",
       "dev": true
     },
     "jsdom": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^5.15.1",
     "eslint-config-google": "^0.12.0",
     "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-jsdoc": "^4.7.0",
     "eslint-plugin-react": "^7.12.4",
     "express": "^4.16.2",
     "file-loader": "^3.0.1",


### PR DESCRIPTION
- `valid-jsdoc` is deprecated so I've replaced it with `eslint-plugin-jsdoc`
- Warnings for JSdoc only happens when there is documentation that isn't meeting the requirements, but will not warn for missing documentation e.g. React components.
- Added .vscode to the .gitignore as it is a local settings folder and shouldn't be tracked