### PR TITLE
[SERVICE-436] Change production pipeline to require user interaction to deploy to NPM.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,15 +82,15 @@ pipeline {
                 GIT_SHORT_SHA = sh ( script: "git rev-parse --short HEAD", returnStdout: true ).trim()
                 PKG_VERSION = sh ( script: "node -pe \"require('./package.json').version\"", returnStdout: true ).trim()
 
-                BUILD_VERSION = "PKG_VERSION"
+                BUILD_VERSION = "${PKG_VERSION}"
                 CHANNEL = "stable"
                 SERVICE_NAME = "fdc3"
                 MANIFEST_NAME = "app.json"
 
-                S3_LOC = "env.DSERVICE_S3_ROOT" + "SERVICE_NAME" + "/" + "BUILD_VERSION"
-                DOCS_CHANNEL_LOC = "env.DSERVICE_S3_ROOT_DOCS" + "SERVICE_NAME" + "/" + "CHANNEL"
-                DOCS_VERSIONED_LOC = "env.DSERVICE_S3_ROOT_DOCS" + "SERVICE_NAME" + "/" + "BUILD_VERSION"
-                MANIFEST_LOC = "env.DSERVICE_S3_ROOT" + "SERVICE_NAME" + "/" + "MANIFEST_NAME"
+                S3_LOC = "${env.DSERVICE_S3_ROOT}${SERVICE_NAME}/${BUILD_VERSION}"
+                DOCS_CHANNEL_LOC = "${env.DSERVICE_S3_ROOT_DOCS}${SERVICE_NAME}/${CHANNEL}"
+                DOCS_VERSIONED_LOC = "${env.DSERVICE_S3_ROOT_DOCS}${SERVICE_NAME}/${BUILD_VERSION}"
+                MANIFEST_LOC = "${env.DSERVICE_S3_ROOT}${SERVICE_NAME}/${MANIFEST_NAME}"
             }
             stages {
                 stage("Build & Deploy to CDN (Production)") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,15 +82,15 @@ pipeline {
                 GIT_SHORT_SHA = sh ( script: "git rev-parse --short HEAD", returnStdout: true ).trim()
                 PKG_VERSION = sh ( script: "node -pe \"require('./package.json').version\"", returnStdout: true ).trim()
 
-                BUILD_VERSION = PKG_VERSION
+                BUILD_VERSION = "PKG_VERSION"
                 CHANNEL = "stable"
                 SERVICE_NAME = "fdc3"
                 MANIFEST_NAME = "app.json"
 
-                S3_LOC = env.DSERVICE_S3_ROOT + SERVICE_NAME + "/" + BUILD_VERSION
-                DOCS_CHANNEL_LOC = env.DSERVICE_S3_ROOT_DOCS + SERVICE_NAME + "/" + CHANNEL
-                DOCS_VERSIONED_LOC = env.DSERVICE_S3_ROOT_DOCS + SERVICE_NAME + "/" + BUILD_VERSION
-                MANIFEST_LOC = env.DSERVICE_S3_ROOT + SERVICE_NAME + "/" + MANIFEST_NAME
+                S3_LOC = "env.DSERVICE_S3_ROOT" + "SERVICE_NAME" + "/" + "BUILD_VERSION"
+                DOCS_CHANNEL_LOC = "env.DSERVICE_S3_ROOT_DOCS" + "SERVICE_NAME" + "/" + "CHANNEL"
+                DOCS_VERSIONED_LOC = "env.DSERVICE_S3_ROOT_DOCS" + "SERVICE_NAME" + "/" + "BUILD_VERSION"
+                MANIFEST_LOC = "env.DSERVICE_S3_ROOT" + "SERVICE_NAME" + "/" + "MANIFEST_NAME"
             }
             stages {
                 stage("Build & Deploy to CDN (Production)") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                     }
                 }
 
-                stage('Integation Tests') {
+                stage('Integration Tests') {
                     agent { label 'win10-dservices' }
                     steps {
                         bat "npm i"
@@ -78,39 +78,53 @@ pipeline {
         stage('Build & Deploy (Production)') {
             agent { label 'linux-slave' }
             when { branch "master" }
-            steps {
-                script {
-                    GIT_SHORT_SHA = sh ( script: "git rev-parse --short HEAD", returnStdout: true ).trim()
-                    PKG_VERSION = sh ( script: "node -pe \"require('./package.json').version\"", returnStdout: true ).trim()
+            environment {
+                GIT_SHORT_SHA = sh ( script: "git rev-parse --short HEAD", returnStdout: true ).trim()
+                PKG_VERSION = sh ( script: "node -pe \"require('./package.json').version\"", returnStdout: true ).trim()
 
-                    BUILD_VERSION = PKG_VERSION
-                    CHANNEL = "stable"
-                    SERVICE_NAME = "fdc3"
-                    MANIFEST_NAME = "app.json"
+                BUILD_VERSION = PKG_VERSION
+                CHANNEL = "stable"
+                SERVICE_NAME = "fdc3"
+                MANIFEST_NAME = "app.json"
 
-                    S3_LOC = env.DSERVICE_S3_ROOT + SERVICE_NAME + "/" + BUILD_VERSION
-                    DOCS_CHANNEL_LOC = env.DSERVICE_S3_ROOT_DOCS + SERVICE_NAME + "/" + CHANNEL
-                    DOCS_VERSIONED_LOC = env.DSERVICE_S3_ROOT_DOCS + SERVICE_NAME + "/" + BUILD_VERSION
-                    MANIFEST_LOC = env.DSERVICE_S3_ROOT + SERVICE_NAME + "/" + MANIFEST_NAME
+                S3_LOC = env.DSERVICE_S3_ROOT + SERVICE_NAME + "/" + BUILD_VERSION
+                DOCS_CHANNEL_LOC = env.DSERVICE_S3_ROOT_DOCS + SERVICE_NAME + "/" + CHANNEL
+                DOCS_VERSIONED_LOC = env.DSERVICE_S3_ROOT_DOCS + SERVICE_NAME + "/" + BUILD_VERSION
+                MANIFEST_LOC = env.DSERVICE_S3_ROOT + SERVICE_NAME + "/" + MANIFEST_NAME
+            }
+            stages {
+                stage("Build & Deploy to CDN (Production)") {
+                    steps {
+                        sh "npm i --ignore-scripts"
+                        sh "SERVICE_VERSION=${BUILD_VERSION} npm run build"
+                        sh "echo ${GIT_SHORT_SHA} > ./dist/SHA.txt"
+                        sh "npm run zip"
+                        sh "npm run docs"
+                        sh "aws s3 cp ./res/provider ${S3_LOC}/ --recursive"
+                        sh "aws s3 cp ./dist/provider ${S3_LOC}/ --recursive"
+                        sh "aws s3 cp ./dist/client/openfin-" + SERVICE_NAME + ".js ${S3_LOC}/"
+
+                        sh "aws s3 cp ./dist/docs ${DOCS_CHANNEL_LOC} --recursive"
+                        sh "aws s3 cp ./dist/docs ${DOCS_VERSIONED_LOC} --recursive"
+                        sh "aws s3 cp ./dist/provider/app.json ${MANIFEST_LOC}"
+                    }
                 }
-                sh "npm i --ignore-scripts"
-                sh "SERVICE_VERSION=${BUILD_VERSION} npm run build"
-                sh "echo ${GIT_SHORT_SHA} > ./dist/SHA.txt"
-                sh "npm run zip"
-                sh "npm run docs"
-                sh "aws s3 cp ./res/provider ${S3_LOC}/ --recursive"
-                sh "aws s3 cp ./dist/provider ${S3_LOC}/ --recursive"
-                sh "aws s3 cp ./dist/client/openfin-" + SERVICE_NAME + ".js ${S3_LOC}/"
-
-                sh "aws s3 cp ./dist/docs ${DOCS_CHANNEL_LOC} --recursive"
-                sh "aws s3 cp ./dist/docs ${DOCS_VERSIONED_LOC} --recursive"
-                sh "aws s3 cp ./dist/provider/app.json ${MANIFEST_LOC}"
-
-                withCredentials([string(credentialsId: "NPM_TOKEN_WRITE", variable: 'NPM_TOKEN')]) {
-                    sh "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > $WORKSPACE/.npmrc"
+                stage("Deploy Client to NPM (Production)") {
+                    input {
+                        message "Would you like to deploy the client to NPM?"
+                        parameters {
+                            choice(name: 'DEPLOY_CLIENT', choices: ['Yes', 'No'], description: '') 
+                        }
+                    }
+                    when {expression { DEPLOY_CLIENT == 'Yes' }}
+                    steps {
+                        withCredentials([string(credentialsId: "NPM_TOKEN_WRITE", variable: 'NPM_TOKEN')]) {
+                            sh "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > $WORKSPACE/.npmrc"
+                        }
+                        echo "publishing to npm, version: " + BUILD_VERSION
+                        sh "npm publish"
+                    }
                 }
-                echo "publishing to npm, version: " + BUILD_VERSION
-                sh "npm publish"
             }
         }
     }


### PR DESCRIPTION
Split the production pipeline into two stages - one that deploys to CDN and one that deploys to NPM. In the NPM stage, we take in a user input to choose whether or not we deploy. 