### PR TITLE
[N/A] Fix how we setup up event listeners in test window

### DIFF
--- a/res/test/test-app.html
+++ b/res/test/test-app.html
@@ -45,10 +45,8 @@
             }
 
             for (const eventType of eventTypes) {
-                const nextEventListenerID = window.eventListeners.length;
-
                 const handler = (payload) => {
-                    receivedEvents.push({listenerID, payload});
+                    receivedEvents.push({listenerID: 0, payload});
                 };
 
                 const unsubscribe = () => {
@@ -56,7 +54,7 @@
                 };
 
                 fdc3.addEventListener(eventType, handler);
-                window.eventListeners[nextEventListenerID] = {eventType, handler, unsubscribe};
+                window.eventListeners[0] = {eventType, handler, unsubscribe};
             }
         }
     </script>


### PR DESCRIPTION
We can safely depend on `eventListeners` being an empty array here, and we were setting `listenerID` to undefined. This wasn't (I think) the cause of the test failures, but this does tidy up where things were working by luck