### PR TITLE
[SERVICE-456] Implement findIntentsByContext

### DIFF
--- a/res/provider/sample-app-directory.json
+++ b/res/provider/sample-app-directory.json
@@ -29,7 +29,11 @@
         {"icon": "http://localhost:3923/demo/img/app-icons/contacts.svg"}
     ],
     "intents": [
-        {"name": "fdc3.SaveContact"}
+        {
+            "name": "fdc3.SaveContact",
+            "contexts": ["fdc3.contact"],
+            "displayName": "Save"
+        }
     ]
 },
 {
@@ -47,8 +51,22 @@
         {"icon": "http://localhost:3923/demo/img/app-icons/dialer.svg"}
     ],
     "intents": [
-        {"name": "fdc3.StartCall"},
-        {"name": "fdc3.DialCall"}
+        {
+            "name": "fdc3.StartCall",
+            "displayName": "Call",
+            "contexts": ["fdc3.contact"],
+            "customConfig": {
+                "icon": "fa-phone"
+            }
+        },
+        {
+            "name": "fdc3.DialCall",
+            "displayName": "Dial",
+            "contexts": ["fdc3.contact"],
+            "customConfig": {
+                "icon": "fa-tty"
+            }
+        }
     ]
 },
 {
@@ -66,7 +84,11 @@
         {"icon": "http://localhost:3923/demo/img/app-icons/charts.svg"}
     ],
     "intents": [
-        {"name": "fdc3.ViewChart"}
+        {
+            "name": "fdc3.ViewChart",
+            "contexts": ["fdc3.instrument"],
+            "displayName": "View Chart"
+        }
     ]
 },
 {
@@ -84,7 +106,11 @@
         {"icon": "http://localhost:3923/demo/img/app-icons/charts.svg"}
     ],
     "intents": [
-        {"name": "fdc3.ViewChart"}
+        {
+            "name": "fdc3.ViewChart",
+            "contexts": ["fdc3.instrument"],
+            "displayName": "View Chart"
+        }
     ]
 },
 {
@@ -102,6 +128,10 @@
         {"icon": "http://localhost:3923/demo/img/app-icons/charts.svg"}
     ],
     "intents": [
-        {"name": "fdc3.ViewChart"}
+        {
+            "name": "fdc3.ViewChart",
+            "contexts": ["fdc3.instrument"],
+            "displayName": "View Chart"
+        }
     ]
 }]

--- a/res/test/sample-app-directory.json
+++ b/res/test/sample-app-directory.json
@@ -16,11 +16,33 @@
         }
     ],
     "intents": [
-        {"name": "test.IntentName"},
-        {"name": "DialCall"},
-        {"name": "StartCall"},
-        {"name": "SaveContact"},
-        {"name": "ViewChart"}
+        {
+            "name": "test.IntentName",
+            "displayName": "Test Intent"
+        },
+        {
+            "name": "DialCall",
+            "displayName": "Dial",
+            "contexts": ["contact"],
+            "customConfig": {
+                "icon": "fa-tty"
+            }
+        },
+        {
+            "name": "StartCall",
+            "displayName": "Call",
+            "customConfig": {
+                "icon": "fa-phone"
+            }
+        },
+        {
+            "name": "SaveContact",
+            "displayName": "Save"
+        },
+        {
+            "name": "ViewChart",
+            "displayName": "View Chart"
+        }
     ]
 },
 {

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -149,14 +149,14 @@ export async function findIntent(intent: string, context?: Context): Promise<App
 /**
  * Find all the available intents for a particular context.
  *
- * findIntents is effectively granting programmatic access to the Desktop Agent's resolver.
+ * findIntentsByContext is effectively granting programmatic access to the Desktop Agent's resolver.
  * A promise resolving to all the intents, their metadata and metadata about the apps that registered it is returned,
  * based on the context export types the intents have registered.
  *
  * If the resolution fails, the promise will return an `Error` with a string from the `ResolveError` export enumeration.
  *
  * ```javascript
- * // I have a context object, and I want to know what I can do with it, hence, I look for for intents...
+ * // I have a context object, and I want to know what I can do with it, hence, I look for intents...
  * const appIntents = await agent.findIntentsForContext(context);
  *
  * // returns for example:
@@ -197,7 +197,7 @@ export function broadcast(context: Context): void {
  * Raises an intent to the desktop agent to resolve.
  * ```javascript
  * //raise an intent to start a chat with a given contact
- * const intentR = await agent.findIntents("StartChat", context);
+ * const intentR = await agent.findIntent("StartChat", context);
  * //use the IntentResolution object to target the same chat app with a new context
  * agent.raiseIntent("StartChat", newContext, intentR.source);
  * ```

--- a/src/demo/apps/ContactsApp.tsx
+++ b/src/demo/apps/ContactsApp.tsx
@@ -54,9 +54,9 @@ export function ContactsApp(): React.ReactElement {
             type: 'fdc3.contact',
             name: '',
             id: {}
-        }).then(appIntents => {
-            console.log('setAppIntents', appIntents);
-            setAppIntents(appIntents);
+        }).then(foundAppIntents => {
+            console.log('setAppIntents', foundAppIntents);
+            setAppIntents(foundAppIntents);
         });
     }, []);
 

--- a/src/demo/apps/ContactsApp.tsx
+++ b/src/demo/apps/ContactsApp.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import * as fdc3 from '../../client/main';
 import {ContactsTable} from '../components/contacts/ContactsTable';
-import {Context, ContactContext} from '../../client/main';
+import {Context, ContactContext, AppIntent} from '../../client/main';
 import '../../../res/demo/css/w3.css';
 import {ContextChannelSelector} from '../components/ContextChannelSelector/ContextChannelSelector';
 
@@ -48,6 +48,18 @@ export function ContactsApp(): React.ReactElement {
         }
     }
 
+    const [appIntents, setAppIntents] = React.useState([] as AppIntent[]);
+    React.useEffect(() => {
+        fdc3.findIntentsByContext({
+            type: 'fdc3.contact',
+            name: '',
+            id: {}
+        }).then(appIntents => {
+            console.log('setAppIntents', appIntents);
+            setAppIntents(appIntents);
+        });
+    }, []);
+
     React.useEffect(() => {
         document.title = 'Contacts';
     }, []);
@@ -73,7 +85,7 @@ export function ContactsApp(): React.ReactElement {
     return (
         <React.Fragment>
             <ContextChannelSelector />
-            <ContactsTable items={contacts} />
+            <ContactsTable items={contacts} appIntents={appIntents} />
         </React.Fragment>
     );
 }

--- a/src/demo/components/contacts/ContactsRow.tsx
+++ b/src/demo/components/contacts/ContactsRow.tsx
@@ -4,31 +4,34 @@ import * as fdc3 from '../../../client/main';
 import {ContactContext} from '../../../client/context';
 import {Contact} from '../../apps/ContactsApp';
 import {IntentButton} from '../common/IntentButton';
-
 import './ContactsRow.css';
-
+import {AppIntent} from '../../../client/main';
 
 interface ContactRowProps {
     item: Contact;
     selected: boolean;
     handleSelect: (item: Contact | null) => void;
+    appIntents: AppIntent[];
 }
 
 export function ContactsRow(props: ContactRowProps): React.ReactElement {
     const {item, selected, handleSelect} = props;
 
-    const handleDial = async (): Promise<void> => {
+    const handleAppIntent = async (appIntent: AppIntent): Promise<void> => {
         if (handleSelect) {
             handleSelect(null);
         }
-        await fdc3.raiseIntent(fdc3.Intents.DIAL_CALL, getContext());
+        await fdc3.raiseIntent(appIntent.intent.name, getContext());
     };
 
-    const handleCall = async (): Promise<void> => {
-        if (handleSelect) {
-            handleSelect(null);
+    const getIntentIcon = (appIntent: AppIntent): string => {
+        if (appIntent && appIntent.apps.length > 0 && appIntent.apps[0].intents) {
+            const intent = appIntent.apps[0].intents.find(intent => intent.name===appIntent.intent.name);
+            if (intent && intent.customConfig) {
+                return intent.customConfig.icon;
+            }
         }
-        await fdc3.raiseIntent(fdc3.Intents.START_CALL, getContext());
+        return 'fa-file';
     };
 
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -56,8 +59,16 @@ export function ContactsRow(props: ContactRowProps): React.ReactElement {
             <td>{item.email}</td>
             <td>{item.phone}</td>
             <td>
-                <IntentButton action={handleDial} title="Dial" iconClassName="fa-tty" />
-                <IntentButton action={handleCall} title="Call" iconClassName="fa-phone" />
+                {
+                    (props.appIntents || []).map(appIntent => (
+                        <IntentButton
+                            key={appIntent.intent.name}
+                            action={() => handleAppIntent(appIntent)}
+                            title={appIntent.intent.displayName}
+                            iconClassName={getIntentIcon(appIntent)}
+                        />
+                    ))
+                }
             </td>
         </tr>
     );

--- a/src/demo/components/contacts/ContactsRow.tsx
+++ b/src/demo/components/contacts/ContactsRow.tsx
@@ -26,7 +26,7 @@ export function ContactsRow(props: ContactRowProps): React.ReactElement {
 
     const getIntentIcon = (appIntent: AppIntent): string => {
         if (appIntent && appIntent.apps.length > 0 && appIntent.apps[0].intents) {
-            const intent = appIntent.apps[0].intents.find(intent => intent.name===appIntent.intent.name);
+            const intent = appIntent.apps[0].intents.find(intent => intent.name === appIntent.intent.name);
             if (intent && intent.customConfig) {
                 return intent.customConfig.icon;
             }

--- a/src/demo/components/contacts/ContactsTable.tsx
+++ b/src/demo/components/contacts/ContactsTable.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 
 import {Contact} from '../../apps/ContactsApp';
+import {AppIntent} from '../../../client/main';
 
 import {ContactsRow} from './ContactsRow';
 
 interface ContactTableProps {
     items?: Contact[];
+    appIntents: AppIntent[]
 }
 
 export function ContactsTable(props: ContactTableProps): React.ReactElement {
@@ -24,7 +26,12 @@ export function ContactsTable(props: ContactTableProps): React.ReactElement {
             </thead>
             <tbody>
                 {
-                    items!.map((item) => <ContactsRow key={item.name} item={item} selected={item === selectedItem} handleSelect={setSelectedItem} />)}
+                    items!.map((item) => <ContactsRow
+                        key={item.name}
+                        item={item}
+                        selected={item === selectedItem}
+                        appIntents={props.appIntents}
+                        handleSelect={setSelectedItem} />)}
             </tbody>
         </table>
     );

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import {injectable, inject} from 'inversify';
+import {inject, injectable} from 'inversify';
 import {Identity} from 'openfin/_v2/main';
 import {ProviderIdentity} from 'openfin/_v2/api/interappbus/channel/channel';
 
@@ -8,7 +8,7 @@ import {AppIntent, IntentResolution, Application, Intent, Channel} from '../clie
 
 import {Inject} from './common/Injectables';
 import {AppDirectory} from './model/AppDirectory';
-import {Model, FindFilter} from './model/Model';
+import {FindFilter, Model} from './model/Model';
 import {ContextHandler} from './controller/ContextHandler';
 import {IntentHandler} from './controller/IntentHandler';
 import {APIHandler} from './APIHandler';
@@ -97,11 +97,9 @@ export class Main {
 
     private async findIntentsByContext (payload: FindIntentsByContextPayload): Promise<AppIntent[]> {
         if (payload.context && payload.context.type) {
-            const apps = await this._directory.getAppIntentsByContext(payload.context.type);
-            return apps;
+            return this._directory.getAppIntentsByContext(payload.context.type);
         } else {
-            // TODO: Choose the right message
-            throw new Error('Context not valid');
+            throw new Error(`Context not valid. context = ${JSON.stringify(payload.context)}`);
         }
     }
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -96,7 +96,13 @@ export class Main {
     }
 
     private async findIntentsByContext (payload: FindIntentsByContextPayload): Promise<AppIntent[]> {
-        return [];
+        if (payload.context && payload.context.type) {
+            const apps = await this._directory.getAppIntentsByContext(payload.context.type);
+            return apps;
+        } else {
+            // TODO: Choose the right message
+            throw new Error('Context not valid');
+        }
     }
 
     private async broadcast(payload: BroadcastPayload, source: ProviderIdentity): Promise<void> {

--- a/src/provider/model/AppDirectory.ts
+++ b/src/provider/model/AppDirectory.ts
@@ -42,9 +42,9 @@ export class AppDirectory {
             });
         });
         Object.values(appIntentsByName).forEach(appIntent => {
-            appIntent.apps.sort((a, b) => a.appId.localeCompare(b.appId));
+            appIntent.apps.sort((a, b) => a.appId.localeCompare(b.appId, 'en'));
         });
-        return Object.values(appIntentsByName).sort((a, b) => a.intent.name.localeCompare(b.intent.name));
+        return Object.values(appIntentsByName).sort((a, b) => a.intent.name.localeCompare(b.intent.name, 'en'));
     }
 
     public async getAllApps(): Promise<Application[]> {

--- a/src/provider/model/AppDirectory.ts
+++ b/src/provider/model/AppDirectory.ts
@@ -24,7 +24,6 @@ export class AppDirectory {
     public async getAppIntentsByContext(contextType: string): Promise<AppIntent[]> {
         await this.fetchData();
         const appIntentsByName: { [intentName: string]: AppIntent } = {};
-        console.log('getAppIntentsByContext', contextType, this._directory);
         this._directory.forEach((app: Application) => {
             (app.intents || []).forEach(intent => {
                 if (intent.contexts && intent.contexts.includes(contextType)) {
@@ -42,7 +41,6 @@ export class AppDirectory {
                 }
             });
         });
-        console.log('getAppIntentsByContext', appIntentsByName,);
         Object.values(appIntentsByName).forEach(appIntent => {
             appIntent.apps.sort((a, b) => a.appId.localeCompare(b.appId));
         });

--- a/src/provider/model/AppDirectory.ts
+++ b/src/provider/model/AppDirectory.ts
@@ -24,6 +24,7 @@ export class AppDirectory {
     public async getAppIntentsByContext(contextType: string): Promise<AppIntent[]> {
         await this.fetchData();
         const appIntentsByName: { [intentName: string]: AppIntent } = {};
+        console.log('getAppIntentsByContext', contextType, this._directory);
         this._directory.forEach((app: Application) => {
             (app.intents || []).forEach(intent => {
                 if (intent.contexts && intent.contexts.includes(contextType)) {
@@ -41,6 +42,7 @@ export class AppDirectory {
                 }
             });
         });
+        console.log('getAppIntentsByContext', appIntentsByName,);
         Object.values(appIntentsByName).forEach(appIntent => {
             appIntent.apps.sort((a, b) => a.appId.localeCompare(b.appId));
         });

--- a/test/demo/findIntentsByContext.test.ts
+++ b/test/demo/findIntentsByContext.test.ts
@@ -18,7 +18,10 @@ describe('Resolving intents by context, findIntentsByContext', () => {
         const invalidContext = {
             twitter: '@testname'
         };
-        test('the promise rejects', async () => {
+        test('The promise rejects', async () => {
+            // Typescript catches sending an invalid context here, but we want to validate
+            // that in the provider as well, so we want to test passing an invalid one.
+            // That is why we need to ignore the next line.
             // @ts-ignore
             await expect(fdc3Remote.findIntentsByContext(testManagerIdentity, invalidContext))
                 .rejects
@@ -32,7 +35,7 @@ describe('Resolving intents by context, findIntentsByContext', () => {
             name: 'Test Name'
         };
 
-        test('the promise resolves to an empty array', async () => {
+        test('The promise resolves to an empty array', async () => {
             const receivedAppIntents = await fdc3Remote.findIntentsByContext(testManagerIdentity, context);
             expect(receivedAppIntents).toEqual([]);
         });
@@ -43,7 +46,7 @@ describe('Resolving intents by context, findIntentsByContext', () => {
             type: 'contact',
             name: 'Test Name'
         };
-        test('the promise resolves to an array of all compatible AppIntents', async () => {
+        test('The promise resolves to an array of all compatible AppIntents', async () => {
             const receivedAppIntents = await fdc3Remote.findIntentsByContext(testManagerIdentity, context);
             expect(receivedAppIntents).toEqual([
                 {

--- a/test/demo/findIntentsByContext.test.ts
+++ b/test/demo/findIntentsByContext.test.ts
@@ -1,0 +1,64 @@
+import 'jest';
+import {fin} from './utils/fin';
+import * as fdc3Remote from './utils/fdc3RemoteExecution';
+
+const testManagerIdentity = {
+    uuid: 'test-app',
+    name: 'test-app'
+};
+
+
+describe('Resolving intents by context, findIntentsByContext', () => {
+    beforeEach(async () => {
+        // The main launcher app should remain running for the duration of all tests.
+        await expect(fin.Application.wrapSync(testManagerIdentity).isRunning()).resolves.toBe(true);
+    });
+
+    describe('When calling findIntentsByContext with an invalid context', () => {
+        const invalidContext = {
+            twitter: '@testname'
+        };
+        test('the promise rejects', async () => {
+            // @ts-ignore
+            await expect(fdc3Remote.findIntentsByContext(testManagerIdentity, invalidContext))
+                .rejects
+                .toThrow(`Context not valid. context = ${JSON.stringify(invalidContext)}`);
+        });
+    });
+
+    describe('When calling findIntentsByContext with a context type not accepted by any directory app', () => {
+        const context = {
+            type: 'test.ContextTypeUnknown',
+            name: 'Test Name'
+        };
+
+        test('the promise resolves to an empty array', async () => {
+            const receivedAppIntents = await fdc3Remote.findIntentsByContext(testManagerIdentity, context);
+            expect(receivedAppIntents).toEqual([]);
+        });
+    });
+
+    describe('When calling findIntentsByContext with a context type accepted by some directory app', () => {
+        const context = {
+            type: 'contact',
+            name: 'Test Name'
+        };
+        test('the promise resolves to an array of all compatible AppIntents', async () => {
+            const receivedAppIntents = await fdc3Remote.findIntentsByContext(testManagerIdentity, context);
+            expect(receivedAppIntents).toEqual([
+                {
+                    intent: {
+                        displayName: 'Dial',
+                        name: 'DialCall'
+                    },
+                    apps: [
+                        expect.objectContaining({
+                            appId: '100',
+                            name: 'test-app-1'
+                        })
+                    ]
+                }
+            ]);
+        });
+    });
+});

--- a/test/demo/resolveByContext.test.ts
+++ b/test/demo/resolveByContext.test.ts
@@ -1,9 +1,0 @@
-import 'jest';
-
-// TODO: findIntentsByContext is not yet supported by the provider. Tests should be filled in once provider is update to support it (SERVICE-392?)
-describe('Resolving intents by context', () => {
-    test.todo('Calling findIntentsByContext with a context type accepted by at least one directory app \
-        the promise resolves to an array of all compatible AppIntents');
-    test.todo('Calling findIntentsByContext with a context type not accepted by any directory app \
-        the promise resolves to an empty array');
-});

--- a/test/demo/utils/fdc3RemoteExecution.ts
+++ b/test/demo/utils/fdc3RemoteExecution.ts
@@ -12,7 +12,7 @@
 
 import {Identity} from 'openfin/_v2/main';
 
-import {Application, Context, IntentType, ChannelId, Channel} from '../../../src/client/main';
+import {Application, Context, IntentType, ChannelId, Channel, AppIntent} from '../../../src/client/main';
 import {RaiseIntentPayload} from '../../../src/client/internal';
 import {FDC3Event, FDC3EventType} from '../../../src/client/connection';
 
@@ -262,4 +262,10 @@ export async function getRemoteEventListener(executionTarget: Identity, listener
             }
         };
     }
+}
+
+export async function findIntentsByContext(executionTarget: Identity, context: Context): Promise<AppIntent[]> {
+    return ofBrowser.executeOnWindow(executionTarget, async function(this: TestWindowContext, context: Context): Promise<AppIntent[]> {
+        return this.fdc3.findIntentsByContext(context);
+    }, context);
 }

--- a/test/provider/AppDirectory.unittest.ts
+++ b/test/provider/AppDirectory.unittest.ts
@@ -1,0 +1,103 @@
+import 'jest';
+import 'reflect-metadata';
+
+import {Application} from '../../src/client/directory';
+import {AppDirectory} from '../../src/provider/model/AppDirectory';
+import {AppIntent} from '../../src/client/main';
+
+const intentA = {
+    name: 'testIntent.StartChat',
+    contexts: ['testContext.User'],
+    customConfig: {}
+};
+const intentB = {
+    name: 'testIntent.SendEmail',
+    contexts: ['testContext.User'],
+    customConfig: {}
+};
+const intentC = {
+    name: 'testIntent.StartChat',
+    contexts: ['testContext.User', 'testContext.Bot'],
+    customConfig: {}
+};
+const intentD = {
+    name: 'testIntent.ShowChart',
+    contexts: ['testContext.Instrument'],
+    customConfig: {}
+};
+const fakeApp1 = {
+    appId: '1',
+    name: 'App 1',
+    manifestType: '',
+    manifest: '',
+    intents: [intentA, intentB]
+};
+const fakeApp2 = {
+    appId: '2',
+    name: 'App 2',
+    manifestType: '',
+    manifest: '',
+    intents: [intentC, intentD]
+};
+
+const fakeAppDirectory: Application[] = [fakeApp1, fakeApp2];
+
+const mockJson = jest.fn();
+
+beforeEach(() => {
+    jest.restoreAllMocks();
+
+    (global as any).fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: mockJson
+    });
+});
+
+describe('Given an App Directory with apps', () => {
+    const appDirectory = new AppDirectory();
+
+    describe('When finding app intents by context with a context implemented by 2 intents in both apps', () => {
+        beforeEach(() => {
+            mockJson.mockResolvedValue(fakeAppDirectory);
+        });
+        it('Should return 2 intents', async () => {
+            const intents = await appDirectory.getAppIntentsByContext('testContext.User');
+
+            expect(intents).toEqual([
+                {
+                    intent: {name: 'testIntent.SendEmail', displayName: 'testIntent.SendEmail'},
+                    apps: [fakeApp1]
+                },
+                {
+                    intent: {name: 'testIntent.StartChat', displayName: 'testIntent.StartChat'},
+                    apps: [fakeApp1, fakeApp2]
+                }
+            ] as AppIntent[]);
+        });
+    });
+    describe('When finding app intents by context with a context not implemented by any intent', () => {
+        beforeEach(() => {
+            mockJson.mockResolvedValue(fakeAppDirectory);
+        });
+        it('Should return an empty array', async () => {
+            const intents = await appDirectory.getAppIntentsByContext('testContext.NonExistent');
+
+            expect(intents).toEqual([] as AppIntent[]);
+        });
+    });
+    describe('When finding app intents by context with a context implemented by only 1 intent in 1 app', () => {
+        beforeEach(() => {
+            mockJson.mockResolvedValue(fakeAppDirectory);
+        });
+        it('Should return 1 intent in 1 app', async () => {
+            const intents = await appDirectory.getAppIntentsByContext('testContext.Instrument');
+
+            expect(intents).toEqual([
+                {
+                    intent: {name: 'testIntent.ShowChart', displayName: 'testIntent.ShowChart'},
+                    apps: [fakeApp2]
+                }
+            ] as AppIntent[]);
+        });
+    });
+});

--- a/test/provider/AppDirectory.unittest.ts
+++ b/test/provider/AppDirectory.unittest.ts
@@ -75,6 +75,7 @@ describe('Given an App Directory with apps', () => {
             ] as AppIntent[]);
         });
     });
+
     describe('When finding app intents by context with a context not implemented by any intent', () => {
         beforeEach(() => {
             mockJson.mockResolvedValue(fakeAppDirectory);
@@ -85,6 +86,7 @@ describe('Given an App Directory with apps', () => {
             expect(intents).toEqual([] as AppIntent[]);
         });
     });
+
     describe('When finding app intents by context with a context implemented by only 1 intent in 1 app', () => {
         beforeEach(() => {
             mockJson.mockResolvedValue(fakeAppDirectory);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,13 +3,10 @@
     "compilerOptions": {
       "rootDir": "..",
       "outDir": "../dist/test",
-      "target": "es2017",
-      "module": "commonjs",
-      "lib": [
-        "dom",
-        "es7"
-      ],
       "esModuleInterop": false,
+      "types": ["node", "openfin", "reflect-metadata"],
+      "experimentalDecorators": true,
+      "emitDecoratorMetadata": true
     },
     "exclude": [
       "../node_modules",


### PR DESCRIPTION
Implements https://appoji.jira.com/browse/SERVICE-456

- Adds an implementation of the FDC3 API method findIntentsByContext
- Changes the "Contacts" demo app to use it to display the contact actions.
- As part of that, it introduces a "customConfig.icon" property in the intents in the app directory.  This usage is allowed by the spec, and a perfectly valid example of how to do it, but not intended as the prescriptive way to deal with intent icons.  UI is out of scope for the FDC3 v1 standard.

This touches the same files as https://github.com/HadoukenIO/fdc3-service/pull/68.  
It may make more sense to merge 68 first, then deal with any conflicts here.