### PR TITLE
[SERVICE-460] FDC3 Errors (foundation)

### DIFF
--- a/res/test/test-app.html
+++ b/res/test/test-app.html
@@ -7,6 +7,21 @@
         document.title = title;
     </script>
     <script>
+        /**
+         * Mirror of FDC3Error.serialize(), makes sure puppeteer serializes all the relevant error information (for FDC3Error's) back to the test host
+         */
+        function errorHandler(error) {
+            if (error && error.code && error.message) {
+                throw new Error(JSON.stringify({
+                    name: error.name,
+                    code: error.code,
+                    message: error.message
+                }));
+            } 
+            
+            throw error;
+        }
+
         window.contextListeners = [];
         window.intentListeners = [];
         window.eventListeners = [];

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -69,15 +69,6 @@ export async function tryServiceDispatch<T extends APIFromClientTopic>(action: T
     const channel: ChannelClient = await channelPromise;
     return (channel.dispatch(action, payload) as Promise<APIFromClient[T][1]>)
         .catch(error => {
-            let errorToRethrow = error;
-            try {
-                const fdc3Error = JSON.parse(error.message);
-                if (fdc3Error && fdc3Error.code && fdc3Error.message) {
-                    errorToRethrow = new FDC3Error(fdc3Error.code, fdc3Error.message);
-                }
-            } catch (e) {
-                // Didn't parse, we will rethrow the error param
-            }
-            throw errorToRethrow;
+            throw FDC3Error.deserialize(error);
         });
 }

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -1,0 +1,21 @@
+export enum OpenError {
+  AppNotFound = 'AppNotFound',
+  ErrorOnLaunch = 'ErrorOnLaunch',
+  AppTimeout = 'AppTimeout',
+  ResolverUnavailable = 'ResolverUnavailable'
+}
+
+export enum ResolveError {
+  NoAppsFound = 'NoAppsFound',
+  ResolverUnavailable = 'ResolverUnavailable',
+  ResolverTimeout = 'ResolverTimeout',
+  InvalidContext = 'InvalidContext'
+}
+
+export class FDC3Error extends Error{
+  public code: string;
+  public constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+  }
+}

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -1,18 +1,18 @@
 export enum OpenError {
-  AppNotFound = 'AppNotFound',
-  ErrorOnLaunch = 'ErrorOnLaunch',
-  AppTimeout = 'AppTimeout',
-  ResolverUnavailable = 'ResolverUnavailable'
+    AppNotFound = 'AppNotFound',
+    ErrorOnLaunch = 'ErrorOnLaunch',
+    AppTimeout = 'AppTimeout',
+    ResolverUnavailable = 'ResolverUnavailable'
 }
 
 export enum ResolveError {
-  NoAppsFound = 'NoAppsFound',
-  ResolverUnavailable = 'ResolverUnavailable',
-  ResolverTimeout = 'ResolverTimeout',
-  InvalidContext = 'InvalidContext'
+    NoAppsFound = 'NoAppsFound',
+    ResolverUnavailable = 'ResolverUnavailable',
+    ResolverTimeout = 'ResolverTimeout',
+    InvalidContext = 'InvalidContext'
 }
 
-export class FDC3Error extends Error{
+export class FDC3Error extends Error {
     /**
      * If error is FDC3 specific, serialize it as { code, message } so it can be identified as an `FDC3Error` at the client's end.
      * Otherwise return the error itself
@@ -44,15 +44,14 @@ export class FDC3Error extends Error{
         } catch (e) {
             // Payload wasn't a serialized JSON object
         }
-        
+
         return error;
     }
 
-
-  public code: string;
-  public constructor(code: string, message: string) {
-      super(message);
-      this.name = 'FDC3Error';
-      this.code = code;
-  }
+    public code: string;
+    public constructor(code: string, message: string) {
+        super(message);
+        this.name = 'FDC3Error';
+        this.code = code;
+    }
 }

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -13,9 +13,46 @@ export enum ResolveError {
 }
 
 export class FDC3Error extends Error{
+    /**
+     * If error is FDC3 specific, serialize it as { code, message } so it can be identified as an `FDC3Error` at the client's end.
+     * Otherwise return the error itself
+     * @param error The error
+     */
+    public static serialize(error: Error | FDC3Error): Error {
+        // TODO: is use of `instanceof` OK? or should use `if (error && error.code && error.message)` ?
+        if (error instanceof FDC3Error) {
+            return new Error(JSON.stringify({
+                code: error.code,
+                message: error.message
+            }));
+        }
+
+        return error;
+    }
+
+    /**
+     * Check if the error was a serialized FDC3 error, and if so reconstruct as a typed FDC3Error
+     * Otherwise return the error itself
+     * @param error The error
+     */
+    public static deserialize(error: Error): Error | FDC3Error {
+        try {
+            const fdc3Error = JSON.parse(error.message);
+            if (fdc3Error && fdc3Error.code && fdc3Error.message) {
+                return new FDC3Error(fdc3Error.code, fdc3Error.message);
+            }
+        } catch (e) {
+            // Payload wasn't a serialized JSON object
+        }
+        
+        return error;
+    }
+
+
   public code: string;
   public constructor(code: string, message: string) {
       super(message);
+      this.name = 'FDC3Error';
       this.code = code;
   }
 }

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -34,7 +34,16 @@ export enum OpenError {
 export enum ResolveError {
     NoAppsFound = 'NoAppsFound',
     ResolverUnavailable = 'ResolverUnavailable',
-    ResolverTimeout = 'ResolverTimeout'
+    ResolverTimeout = 'ResolverTimeout',
+    InvalidContext = 'InvalidContext'
+}
+
+export class FDC3Error extends Error{
+    public code: string;
+    public constructor(code: string, message: string) {
+        super(message);
+        this.code = code;
+    }
 }
 
 /**

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -23,28 +23,7 @@ export * from './contextChannels';
 export * from './context';
 export * from './directory';
 export * from './intents';
-
-export enum OpenError {
-    AppNotFound = 'AppNotFound',
-    ErrorOnLaunch = 'ErrorOnLaunch',
-    AppTimeout = 'AppTimeout',
-    ResolverUnavailable = 'ResolverUnavailable'
-}
-
-export enum ResolveError {
-    NoAppsFound = 'NoAppsFound',
-    ResolverUnavailable = 'ResolverUnavailable',
-    ResolverTimeout = 'ResolverTimeout',
-    InvalidContext = 'InvalidContext'
-}
-
-export class FDC3Error extends Error{
-    public code: string;
-    public constructor(code: string, message: string) {
-        super(message);
-        this.code = code;
-    }
-}
+export * from './errors';
 
 /**
  * Intent descriptor

--- a/src/demo/apps/ContactsApp.tsx
+++ b/src/demo/apps/ContactsApp.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import * as fdc3 from '../../client/main';
 import {ContactsTable} from '../components/contacts/ContactsTable';
-import {Context, ContactContext, AppIntent} from '../../client/main';
+import {Context, ContactContext, AppIntent, ResolveError} from '../../client/main';
 import '../../../res/demo/css/w3.css';
 import {ContextChannelSelector} from '../components/ContextChannelSelector/ContextChannelSelector';
 
@@ -50,14 +50,22 @@ export function ContactsApp(): React.ReactElement {
 
     const [appIntents, setAppIntents] = React.useState([] as AppIntent[]);
     React.useEffect(() => {
-        fdc3.findIntentsByContext({
+        const context = {
             type: 'fdc3.contact',
             name: '',
             id: {}
-        }).then(foundAppIntents => {
-            console.log('setAppIntents', foundAppIntents);
-            setAppIntents(foundAppIntents);
-        });
+        };
+        fdc3.findIntentsByContext(context).then(appIntents => {
+            console.log('setAppIntents', appIntents);
+            setAppIntents(appIntents);
+        })
+            .catch(error => {
+                if (error.code === ResolveError.InvalidContext) {
+                    console.log('Invalid context!', context);
+                } else {
+                    console.log('Error from fdc3.findIntentsByContext', error);
+                }
+            });
     }, []);
 
     React.useEffect(() => {

--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -85,7 +85,18 @@ export class APIHandler<T extends Enum> {
 
         for (const action in actionHandlerMap) {
             if (actionHandlerMap.hasOwnProperty(action)) {
-                this._providerChannel.register(action, actionHandlerMap[action]);
+                this._providerChannel.register(action, (payload, source) =>
+                    actionHandlerMap[action](payload, source)
+                        .catch(error => {
+                            let errorToRethrow = error;
+                            if (error && error.code && error.message) {
+                                errorToRethrow = new Error(JSON.stringify({
+                                    code: error.code,
+                                    message: error.message
+                                }));
+                            }
+                            throw errorToRethrow;
+                        }));
             }
         }
     }

--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -4,6 +4,7 @@ import {ChannelProvider} from 'openfin/_v2/api/interappbus/channel/provider';
 import {Identity} from 'openfin/_v2/main';
 
 import {SERVICE_CHANNEL} from '../client/internal';
+import {FDC3Error} from '../client/errors';
 
 import {Signal1} from './common/Signal';
 
@@ -88,14 +89,7 @@ export class APIHandler<T extends Enum> {
                 this._providerChannel.register(action, (payload, source) =>
                     actionHandlerMap[action](payload, source)
                         .catch(error => {
-                            let errorToRethrow = error;
-                            if (error && error.code && error.message) {
-                                errorToRethrow = new Error(JSON.stringify({
-                                    code: error.code,
-                                    message: error.message
-                                }));
-                            }
-                            throw errorToRethrow;
+                            throw FDC3Error.serialize(error);
                         }));
             }
         }

--- a/src/provider/controller/IntentHandler.ts
+++ b/src/provider/controller/IntentHandler.ts
@@ -69,9 +69,9 @@ export class IntentHandler {
     }
 
     private async fireIntent(intent: Intent, appInfo: Application): Promise<IntentResolution> {
-        const app: AppWindow = await this._model.findOrCreate(appInfo, FindFilter.WITH_INTENT_LISTENER);
-        await app.ensureReadyToReceiveIntent(intent.type);
-        const data = await this._apiHandler.channel.dispatch(app.identity, APIToClientTopic.INTENT, {context: intent.context, intent: intent.type});
+        const appWindow = await this._model.findOrCreate(appInfo, FindFilter.WITH_INTENT_LISTENER);
+        await appWindow.ensureReadyToReceiveIntent(intent.type);
+        const data = await this._apiHandler.channel.dispatch(appWindow.identity, APIToClientTopic.INTENT, {context: intent.context, intent: intent.type});
         const result: IntentResolution = {
             source: appInfo.name,
             version: '1.0.0',

--- a/src/provider/controller/IntentHandler.ts
+++ b/src/provider/controller/IntentHandler.ts
@@ -2,7 +2,7 @@ import {injectable, inject} from 'inversify';
 
 import {Inject} from '../common/Injectables';
 import {Intent} from '../../client/intents';
-import {IntentResolution, Application} from '../../client/main';
+import {IntentResolution, Application, FDC3Error, ResolveError} from '../../client/main';
 import {FindFilter, Model} from '../model/Model';
 import {AppDirectory} from '../model/AppDirectory';
 import {AppWindow} from '../model/AppWindow';
@@ -31,7 +31,7 @@ export class IntentHandler {
         const apps: Application[] = await this._directory.getAppsByIntent(intent.type);
 
         if (apps.length === 0) {
-            throw new Error('No applications available to handle this intent');
+            throw new FDC3Error(ResolveError.NoAppsFound, 'No applications available to handle this intent');
         } else if (apps.length === 1) {
             // Resolve intent immediately
             return this.fireIntent(intent, apps[0]);

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -4,7 +4,7 @@ import {Identity} from 'openfin/_v2/main';
 import {ProviderIdentity} from 'openfin/_v2/api/interappbus/channel/channel';
 
 import {RaiseIntentPayload, APIFromClientTopic, OpenPayload, FindIntentPayload, FindIntentsByContextPayload, BroadcastPayload, APIFromClient, GetAllChannelsPayload, JoinChannelPayload, GetChannelPayload, GetChannelMembersPayload, IntentListenerPayload} from '../client/internal';
-import {AppIntent, IntentResolution, Application, Intent, Channel} from '../client/main';
+import {AppIntent, IntentResolution, Application, Intent, Channel, ResolveError, FDC3Error} from '../client/main';
 
 import {Inject} from './common/Injectables';
 import {AppDirectory} from './model/AppDirectory';
@@ -99,7 +99,7 @@ export class Main {
         if (payload.context && payload.context.type) {
             return this._directory.getAppIntentsByContext(payload.context.type);
         } else {
-            throw new Error(`Context not valid. context = ${JSON.stringify(payload.context)}`);
+            throw new FDC3Error(ResolveError.InvalidContext, `Context not valid. context = ${JSON.stringify(payload.context)}`);
         }
     }
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -68,10 +68,10 @@ export class Main {
         const appInfo: Application|null = await this._directory.getAppByName(payload.name);
 
         if (appInfo) {
-            const app = await this._model.findOrCreate(appInfo, FindFilter.WITH_CONTEXT_LISTENER);
+            const appWindow = await this._model.findOrCreate(appInfo, FindFilter.WITH_CONTEXT_LISTENER);
 
             if (payload.context) {
-                await this._contexts.send(app, payload.context);
+                await this._contexts.send(appWindow, payload.context);
             }
         } else {
             throw new Error(`No app in directory with name: ${payload.name}`);
@@ -79,7 +79,7 @@ export class Main {
     }
 
     private async findIntent(payload: FindIntentPayload): Promise<AppIntent> {
-        let apps;
+        let apps: Application[];
         if (payload.intent) {
             apps = await this._directory.getAppsByIntent(payload.intent);
         } else {
@@ -133,9 +133,9 @@ export class Main {
     }
 
     private async addIntentListener(payload: IntentListenerPayload, identity: ProviderIdentity): Promise<void> {
-        const app = this._model.getWindow(identity);
-        if (app) {
-            app.addIntentListener(payload.intent);
+        const appWindow = this._model.getWindow(identity);
+        if (appWindow) {
+            appWindow.addIntentListener(payload.intent);
             return Promise.resolve();
         } else {
             throw new Error('App not found in model');
@@ -143,9 +143,9 @@ export class Main {
     }
 
     private async removeIntentListener(payload: IntentListenerPayload, identity: ProviderIdentity): Promise<void> {
-        const app = this._model.getWindow(identity);
-        if (app) {
-            app.removeIntentListener(payload.intent);
+        const appWindow = this._model.getWindow(identity);
+        if (appWindow) {
+            appWindow.removeIntentListener(payload.intent);
             return Promise.resolve();
         } else {
             throw new Error('App not found in model');

--- a/src/provider/model/AppDirectory.ts
+++ b/src/provider/model/AppDirectory.ts
@@ -1,13 +1,13 @@
 import {injectable} from 'inversify';
 
-import {Application} from '../../client/directory';
+import {Application, AppName} from '../../client/directory';
 import {AppIntent} from '../../client/main';
 
 @injectable()
 export class AppDirectory {
     private _directory!: Application[];
 
-    public async getAppByName(name: string): Promise<Application|null> {
+    public async getAppByName(name: AppName): Promise<Application|null> {
         await this.fetchData();
         return this._directory.find((app: Application) => {
             return app.name === name;

--- a/src/provider/model/Model.ts
+++ b/src/provider/model/Model.ts
@@ -58,18 +58,18 @@ export class Model {
 
     public findWindows(appInfo: Application, options?: FindOptions): AppWindow[] {
         const {prefer, require} = options || {prefer: undefined, require: undefined};
-        const windows = this._windows.filter((app: AppWindow) => {
-            if (app.appInfo.appId !== appInfo.appId) {
+        const windows = this._windows.filter(appWindow => {
+            if (appWindow.appInfo.appId !== appInfo.appId) {
                 return false;
             } else if (require !== undefined) {
-                return Model.matchesFilter(app, require);
+                return Model.matchesFilter(appWindow, require);
             } else {
                 return true;
             }
         });
 
         if (windows.length > 0 && prefer !== undefined) {
-            const preferredWindows = windows.filter(app => Model.matchesFilter(app, prefer));
+            const preferredWindows = windows.filter(appWindow => Model.matchesFilter(appWindow, prefer));
 
             if (preferredWindows.length > 0) {
                 return preferredWindows;
@@ -109,8 +109,8 @@ export class Model {
 
             if (!this._windows.some(window => window.id === id)) {
                 console.info(`Registering window ${id}`);
-                const app = this._environment.wrapApplication(appInfo, identity);
-                this._windows.push(app);
+                const appWindow = this._environment.wrapApplication(appInfo, identity);
+                this._windows.push(appWindow);
                 this.onWindowAdded.emit();
             } else {
                 console.info(`Ignoring window created event for ${id} - window was already registered`);

--- a/test/demo/findIntentsByContext.test.ts
+++ b/test/demo/findIntentsByContext.test.ts
@@ -1,4 +1,6 @@
 import 'jest';
+import {FDC3Error, ResolveError} from '../../src/client/errors';
+
 import {fin} from './utils/fin';
 import * as fdc3Remote from './utils/fdc3RemoteExecution';
 
@@ -6,7 +8,6 @@ const testManagerIdentity = {
     uuid: 'test-app',
     name: 'test-app'
 };
-
 
 describe('Resolving intents by context, findIntentsByContext', () => {
     beforeEach(async () => {
@@ -26,6 +27,7 @@ describe('Resolving intents by context, findIntentsByContext', () => {
             await expect(fdc3Remote.findIntentsByContext(testManagerIdentity, invalidContext))
                 .rejects
                 .toThrow(`Context not valid. context = ${JSON.stringify(invalidContext)}`);
+            // .toThrowError(new FDC3Error(ResolveError.InvalidContext, `Context not valid. context = ${JSON.stringify(invalidContext)}`));
         });
     });
 

--- a/test/demo/findIntentsByContext.test.ts
+++ b/test/demo/findIntentsByContext.test.ts
@@ -1,5 +1,6 @@
 import 'jest';
-import {FDC3Error, ResolveError} from '../../src/client/errors';
+import {ResolveError} from '../../src/client/errors';
+import {Context} from '../../src/client/context';
 
 import {fin} from './utils/fin';
 import * as fdc3Remote from './utils/fdc3RemoteExecution';
@@ -18,16 +19,12 @@ describe('Resolving intents by context, findIntentsByContext', () => {
     describe('When calling findIntentsByContext with an invalid context', () => {
         const invalidContext = {
             twitter: '@testname'
-        };
-        test('The promise rejects', async () => {
-            // Typescript catches sending an invalid context here, but we want to validate
-            // that in the provider as well, so we want to test passing an invalid one.
-            // That is why we need to ignore the next line.
-            // @ts-ignore
-            await expect(fdc3Remote.findIntentsByContext(testManagerIdentity, invalidContext))
-                .rejects
-                .toThrow(`Context not valid. context = ${JSON.stringify(invalidContext)}`);
-            // .toThrowError(new FDC3Error(ResolveError.InvalidContext, `Context not valid. context = ${JSON.stringify(invalidContext)}`));
+        } as unknown as Context;
+        test('The promise rejects with an FDC3Error', async () => {
+            const findIntentsPromise = fdc3Remote.findIntentsByContext(testManagerIdentity, invalidContext);
+            await expect(findIntentsPromise).rejects.toThrowError(`Context not valid. context = ${JSON.stringify(invalidContext)}`);
+            await expect(findIntentsPromise).rejects.toHaveProperty('name', 'FDC3Error');
+            await expect(findIntentsPromise).rejects.toHaveProperty('code', ResolveError.InvalidContext);
         });
     });
 

--- a/test/demo/raiseIntent.test.ts
+++ b/test/demo/raiseIntent.test.ts
@@ -1,6 +1,7 @@
 import 'jest';
 
 import {INTENT_LISTENER_TIMEOUT} from '../../src/provider/model/AppWindow';
+import {ResolveError} from '../../src/client/errors';
 
 import {fin} from './utils/fin';
 import * as fdc3Remote from './utils/fdc3RemoteExecution';
@@ -89,10 +90,12 @@ describe('Intent listeners and raising intents', () => {
             });
 
             describe('When the target is *not* registered to accept the raised intent', () => {
-                test('When calling raiseIntent the promise rejects with an error', async () => {
+                test('When calling raiseIntent the promise rejects with an FDC3Error', async () => {
                     const resultPromise = fdc3Remote.raiseIntent(testManagerIdentity, invalidPayload.intent, invalidPayload.context, testAppIdentity.appId);
                     // TODO: decide if this is this the error message we want when sending a targeted intent
                     await expect(resultPromise).rejects.toThrowError(/No applications available to handle this intent/);
+                    await expect(resultPromise).rejects.toHaveProperty('name', 'FDC3Error');
+                    await expect(resultPromise).rejects.toHaveProperty('code', ResolveError.NoAppsFound);
                 });
             });
             describe('When the target is not in the directory', () => {

--- a/test/demo/utils/fdc3RemoteExecution.ts
+++ b/test/demo/utils/fdc3RemoteExecution.ts
@@ -277,14 +277,12 @@ export async function findIntentsByContext(executionTarget: Identity, context: C
  * @param error Error returned by puppeteer
  */
 function handlePuppeteerError(error: Error): never {
-    let errorInfo;
-
     try {
         // Strip-away boilerplate added by puppeteer when returning errors from client apps
         const payload = error.message.replace('Evaluation failed: Error: ', '').split('\n')[0];
 
         // Append additional error fields to Error object
-        errorInfo = JSON.parse(payload);
+        const errorInfo = JSON.parse(payload);
         Object.assign(error, errorInfo);
     } catch (e) {
         // Not an FDC3Error, continue as normal

--- a/test/demo/utils/fdc3RemoteExecution.ts
+++ b/test/demo/utils/fdc3RemoteExecution.ts
@@ -71,8 +71,8 @@ export async function getChannelMembers(executionTarget: Identity, channelId: Ch
 
 export async function raiseIntent(executionTarget: Identity, intent: IntentType, context: Context, target?: string): Promise<void> {
     return ofBrowser.executeOnWindow(executionTarget, async function(this: TestWindowContext, payload: RaiseIntentPayload): Promise<void> {
-        await this.fdc3.raiseIntent(payload.intent, payload.context, payload.target);
-    }, {intent, context, target});
+        await this.fdc3.raiseIntent(payload.intent, payload.context, payload.target).catch(this.errorHandler);
+    }, {intent, context, target}).catch(handlePuppeteerError);
 }
 
 export interface RemoteContextListener {
@@ -266,6 +266,28 @@ export async function getRemoteEventListener(executionTarget: Identity, listener
 
 export async function findIntentsByContext(executionTarget: Identity, context: Context): Promise<AppIntent[]> {
     return ofBrowser.executeOnWindow(executionTarget, async function(this: TestWindowContext, context: Context): Promise<AppIntent[]> {
-        return this.fdc3.findIntentsByContext(context);
-    }, context);
+        return this.fdc3.findIntentsByContext(context).catch(this.errorHandler);
+    }, context).catch(handlePuppeteerError);
+}
+
+/**
+ * Puppeteer catches and rethrows errors its own way, losing information on extra fields (e.g. `code` for FDC3Error objects).
+ * So what we do is serialize all these fields into the single `message` from the client apps, then from here strip back whatever puppeteer
+ * added (Evaluation failed...) and parse the actual error object so we can check for the right info in our integration tests.
+ * @param error Error returned by puppeteer
+ */
+function handlePuppeteerError(error: Error): never {
+    let errorInfo;
+
+    try {
+        // Strip-away boilerplate added by puppeteer when returning errors from client apps
+        const payload = error.message.replace('Evaluation failed: Error: ', '').split('\n')[0];
+
+        // Append additional error fields to Error object
+        errorInfo = JSON.parse(payload);
+        Object.assign(error, errorInfo);
+    } catch (e) {
+        // Not an FDC3Error, continue as normal
+    }
+    throw error;
 }

--- a/test/demo/utils/ofPuppeteer.ts
+++ b/test/demo/utils/ofPuppeteer.ts
@@ -15,6 +15,7 @@ export interface TestWindowEventListener {
 export type TestWindowContext = Window&{
     fin: Fin;
     fdc3: typeof import('../../../src/client/main');
+    errorHandler(error: Error): never;
     contextListeners: ContextListener[];
     intentListeners: {[intent: string]: IntentListener[]};
     eventListeners: TestWindowEventListener[];


### PR DESCRIPTION
This PR sets up the infrastructure for FDC3 Errors
- FDC3Error class with `code` and `message` fields, and static methods to serialize/deserialize as a plain Error (with just a string) that can be sent over the wire
- Use of serialize/deserialize at both ends of the communication (client / provider)
- Necessary boilerplate to make the whole thing work in tests (as Puppeteer hijacks errors and appends its own stuff), both on test apps and on the fdc3RemoteExecution side
- Implementation of a couple of FDC3Errors for `raiseIntent` and `findIntentsByContext`
- Made a few renamings / type annotation changes while on a side quest (sorry for the offtopic)