### PR TITLE
[FIX] client not unsubscribing intent listeners

### DIFF
--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -237,10 +237,10 @@ export function addIntentListener(intent: string, handler: (context: Context) =>
         intent,
         handler,
         unsubscribe: () => {
-            const index: number = contextListeners.indexOf(listener);
+            const index: number = intentListeners.indexOf(listener);
 
             if (index >= 0) {
-                contextListeners.splice(index, 1);
+                intentListeners.splice(index, 1);
             }
 
             return index >= 0;


### PR DESCRIPTION
This fixes a client issue with unsubscribing from intents not removing listeners from the correct listeners array.

Spotted this while playing around with the fdc3-service, trying to unsubscribe from intents wasn't working as intended.
