### PR TITLE
[N/A] Only notify provider when first intent listener is added, and last intent listener is removed

### DIFF
--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -228,15 +228,22 @@ export function addIntentListener(intent: string, handler: (context: Context) =>
 
             if (index >= 0) {
                 intentListeners.splice(index, 1);
-                tryServiceDispatch(APIFromClientTopic.REMOVE_INTENT_LISTENER, {intent});
+
+                if (!hasIntentListener(intent)) {
+                    tryServiceDispatch(APIFromClientTopic.REMOVE_INTENT_LISTENER, {intent});
+                }
             }
 
             return index >= 0;
         }
     };
+
+    const hasIntentListenerBefore = hasIntentListener(intent);
     intentListeners.push(listener);
 
-    tryServiceDispatch(APIFromClientTopic.ADD_INTENT_LISTENER, {intent});
+    if (!hasIntentListenerBefore) {
+        tryServiceDispatch(APIFromClientTopic.ADD_INTENT_LISTENER, {intent});
+    }
     return listener;
 }
 
@@ -274,4 +281,8 @@ export function addEventListener(eventType: FDC3EventType, handler: (event: FDC3
 
 export function removeEventListener(eventType: FDC3EventType, handler: (eventPayload: ChannelChangedEvent) => void): void {
     eventEmitter.removeListener(eventType, handler);
+}
+
+function hasIntentListener(intent: string): boolean {
+    return intentListeners.some(intentListener => intentListener.intent === intent);
 }

--- a/test/demo/raiseIntent.test.ts
+++ b/test/demo/raiseIntent.test.ts
@@ -81,12 +81,55 @@ describe('Intent listeners and raising intents', () => {
                     const receivedContexts = await listener.getReceivedContexts();
                     expect(receivedContexts).toEqual([validPayload.context]);
                 });
+                test('When adding a duplicate intent listener, then calling raiseIntent from another app, ' +
+                    'both listeners are triggered exactly once with the correct context', async () => {
+                    const duplicateListener = await fdc3Remote.addIntentListener(testAppIdentity, validPayload.intent);
+
+                    await fdc3Remote.raiseIntent(testManagerIdentity, validPayload.intent, validPayload.context, testAppIdentity.appId);
+
+                    const receivedContexts = await listener.getReceivedContexts();
+                    expect(receivedContexts).toEqual([validPayload.context]);
+
+                    const duplicateReceivedContexts = await duplicateListener.getReceivedContexts();
+                    expect(duplicateReceivedContexts).toEqual([validPayload.context]);
+                });
+                test('When adding a distinct intent listener, then calling raiseIntent from another app, only the first listener is triggered', async () => {
+                    const distinctListener = await fdc3Remote.addIntentListener(testAppIdentity, validPayload.intent + 'distinguisher');
+
+                    await fdc3Remote.raiseIntent(testManagerIdentity, validPayload.intent, validPayload.context, testAppIdentity.appId);
+
+                    const receivedContexts = await listener.getReceivedContexts();
+                    expect(receivedContexts).toEqual([validPayload.context]);
+
+                    const distinctReceivedContexts = await distinctListener.getReceivedContexts();
+                    expect(distinctReceivedContexts).toEqual([]);
+                });
                 test('When calling unsubscribe from the intent listener, then calling raiseIntent from another app, it times out', async () => {
                     await listener.unsubscribe();
                     const resultPromise = fdc3Remote.raiseIntent(testManagerIdentity, validPayload.intent, validPayload.context, testAppIdentity.appId);
 
                     await expect(resultPromise).rejects.toThrowError(`Timeout waiting for intent listener to be added. intent = ${validPayload.intent}`);
                 }, INTENT_LISTENER_TIMEOUT + 500);
+                test('When calling unsubscribe from a second intent listener, then calling raiseIntent from another app, ' +
+                     'the first listener is triggered exactly once with the correct context', async () => {
+                    const shortLivedListener = await fdc3Remote.addIntentListener(testAppIdentity, validPayload.intent);
+                    await shortLivedListener.unsubscribe();
+
+                    await fdc3Remote.raiseIntent(testManagerIdentity, validPayload.intent, validPayload.context, testAppIdentity.appId);
+
+                    const receivedContexts = await listener.getReceivedContexts();
+                    expect(receivedContexts).toEqual([validPayload.context]);
+                });
+                test('When calling unsubscribe from a second intent listener, then calling raiseIntent from another app, ' +
+                     'the second listener is not triggered', async () => {
+                    const shortLivedListener = await fdc3Remote.addIntentListener(testAppIdentity, validPayload.intent);
+                    await shortLivedListener.unsubscribe();
+
+                    await fdc3Remote.raiseIntent(testManagerIdentity, validPayload.intent, validPayload.context, testAppIdentity.appId);
+
+                    const receivedContexts = await shortLivedListener.getReceivedContexts();
+                    expect(receivedContexts).toEqual([]);
+                });
             });
 
             describe('When the target is *not* registered to accept the raised intent', () => {


### PR DESCRIPTION
This fixes an issue whereby the provider could believe the client to have no listeners for a given intent, and adds further integration tests around intents covering this issue.

@spcfran This behaviour seems sensible, though please shout if you disagree