### PR TITLE
[SERVICE-478] Complete base context broadcasting functionality (Unit testing)

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -17,7 +17,7 @@ import {ChannelClient} from 'openfin/_v2/api/interappbus/channel/client';
 
 import {APIFromClientTopic, SERVICE_CHANNEL, SERVICE_IDENTITY, APIFromClient} from './internal';
 import {ChannelChangedEvent} from './contextChannels';
-import {FDC3Error} from './main';
+import {FDC3Error} from './errors';
 
 /**
  * The version of the NPM package.
@@ -40,23 +40,36 @@ export const eventEmitter = new EventEmitter();
 /**
  * Promise to the channel object that allows us to connect to the client
  */
-export let channelPromise: Promise<ChannelClient>;
-// Currently a runtime bug when provider connects to itself. Ideally the provider would never import a file
-// that includes this, but for now it is easier to put a guard in place.
-if (fin.Window.me.uuid !== SERVICE_IDENTITY.uuid || fin.Window.me.name !== SERVICE_IDENTITY.name) {
-    channelPromise = typeof fin === 'undefined' ?
-        Promise.reject(new Error('fin is not defined. The openfin-fdc3 module is only intended for use in an OpenFin application.')) :
-        fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version: PACKAGE_VERSION}}).then((channel: ChannelClient) => {
-            // Register service listeners
-            channel.register('WARN', (payload: any) => console.warn(payload));  // tslint:disable-line:no-any
-            channel.register('event', (event: FDC3Event) => {
-                eventEmitter.emit(event.type, event);
-            });
-            // Any unregistered action will simply return false
-            channel.setDefaultAction(() => false);
+let channelPromise: Promise<ChannelClient>|null = null;
 
-            return channel;
-        });
+if (typeof fin !== 'undefined') {
+    getServicePromise();
+}
+
+export function getServicePromise(): Promise<ChannelClient> {
+    if (!channelPromise) {
+        // Currently a runtime bug when provider connects to itself. Ideally the provider would never import a file
+        // that includes this, but for now it is easier to put a guard in place.
+        if (fin.Window.me.uuid !== SERVICE_IDENTITY.uuid || fin.Window.me.name !== SERVICE_IDENTITY.name) {
+            channelPromise = typeof fin === 'undefined' ?
+                Promise.reject(new Error('fin is not defined. The openfin-fdc3 module is only intended for use in an OpenFin application.')) :
+                fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version: PACKAGE_VERSION}}).then((channel: ChannelClient) => {
+                    // Register service listeners
+                    channel.register('WARN', (payload: any) => console.warn(payload));  // tslint:disable-line:no-any
+                    channel.register('event', (event: FDC3Event) => {
+                        eventEmitter.emit(event.type, event);
+                    });
+                    // Any unregistered action will simply return false
+                    channel.setDefaultAction(() => false);
+
+                    return channel;
+                });
+        } else {
+            channelPromise = Promise.reject<ChannelClient>(new Error('Trying to connect to provider from provider'));
+        }
+    }
+
+    return channelPromise;
 }
 
 /**
@@ -66,7 +79,7 @@ if (fin.Window.me.uuid !== SERVICE_IDENTITY.uuid || fin.Window.me.name !== SERVI
  * @param payload Object containing additional arguments
  */
 export async function tryServiceDispatch<T extends APIFromClientTopic>(action: T, payload: APIFromClient[T][0]): Promise<APIFromClient[T][1]> {
-    const channel: ChannelClient = await channelPromise;
+    const channel: ChannelClient = (await channelPromise)!;
     return (channel.dispatch(action, payload) as Promise<APIFromClient[T][1]>)
         .catch(error => {
             throw FDC3Error.deserialize(error);

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -49,11 +49,11 @@ if (typeof fin !== 'undefined') {
 export function getServicePromise(): Promise<ChannelClient> {
     if (!channelPromise) {
         if (typeof fin === 'undefined') {
-            channelPromise = Promise.reject<ChannelClient>(new Error('Trying to connect to provider from provider'));
-        } else if (fin.Window.me.uuid === SERVICE_IDENTITY.uuid || fin.Window.me.name === SERVICE_IDENTITY.name) {
+            channelPromise = Promise.reject(new Error('fin is not defined. The openfin-fdc3 module is only intended for use in an OpenFin application.'));
+        } else if (fin.Window.me.uuid === SERVICE_IDENTITY.uuid && fin.Window.me.name === SERVICE_IDENTITY.name) {
             // Currently a runtime bug when provider connects to itself. Ideally the provider would never import a file
             // that includes this, but for now it is easier to put a guard in place.
-            channelPromise = Promise.reject(new Error('fin is not defined. The openfin-fdc3 module is only intended for use in an OpenFin application.'));
+            channelPromise = Promise.reject<ChannelClient>(new Error('Trying to connect to provider from provider'));
         } else {
             channelPromise = fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version: PACKAGE_VERSION}}).then((channel: ChannelClient) => {
                 // Register service listeners

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -79,7 +79,7 @@ export function getServicePromise(): Promise<ChannelClient> {
  * @param payload Object containing additional arguments
  */
 export async function tryServiceDispatch<T extends APIFromClientTopic>(action: T, payload: APIFromClient[T][0]): Promise<APIFromClient[T][1]> {
-    const channel: ChannelClient = (await channelPromise)!;
+    const channel: ChannelClient = await getServicePromise();
     return (channel.dispatch(action, payload) as Promise<APIFromClient[T][1]>)
         .catch(error => {
             throw FDC3Error.deserialize(error);

--- a/src/provider/ChannelModel.ts
+++ b/src/provider/ChannelModel.ts
@@ -1,9 +1,14 @@
 import {Identity} from 'openfin/_v2/main';
+import {inject, injectable} from 'inversify';
 
 import {Channel, ChannelId, GLOBAL_CHANNEL_ID, ChannelChangedEvent} from '../client/contextChannels';
 import {Context} from '../client/main';
+import {APIFromClientTopic} from '../client/internal';
 
 import {Signal1} from './common/Signal';
+import {Inject} from './common/Injectables';
+import {APIHandler} from './APIHandler';
+
 
 type IdentityHash = string;
 
@@ -56,12 +61,9 @@ const PURPLE_CHANNEL: Channel = {
     color: 0xFF00FF
 };
 
-export function createChannelModel(connectionSignal: Signal1<Identity>, disconnectionSignal:Signal1<Identity>) {
-    const userChannels = [RED_CHANNEL, ORANGE_CHANNEL, YELLOW_CHANNEL, GREEN_CHANNEL, BLUE_CHANNEL, PURPLE_CHANNEL];
+const USER_CHANNELS = [RED_CHANNEL, ORANGE_CHANNEL, YELLOW_CHANNEL, GREEN_CHANNEL, BLUE_CHANNEL, PURPLE_CHANNEL];
 
-    return new ChannelModel(GLOBAL_CHANNEL, userChannels, connectionSignal, disconnectionSignal);
-}
-
+@injectable()
 export class ChannelModel {
     public readonly onChannelChanged: Signal1<ChannelChangedEvent> = new Signal1<ChannelChangedEvent>();
 
@@ -74,18 +76,18 @@ export class ChannelModel {
 
     private _globalChannel: Channel;
 
-    public constructor(globalChannel: Channel, userChannels: Channel[], onConnection: Signal1<Identity>, onDisconnection:Signal1<Identity>) {
-        this._globalChannel = globalChannel;
+    public constructor(@inject(Inject.API_HANDLER) apiHandler: APIHandler<APIFromClientTopic>) {
+        this._globalChannel = GLOBAL_CHANNEL;
 
         this._channels.splice(0, 0, this._globalChannel);
-        this._channels.splice(0, 0, ...userChannels);
+        this._channels.splice(0, 0, ...USER_CHANNELS);
 
         for (const channel of this._channels) {
             this._channelIdToChannelMap.set(channel.id, channel);
         }
 
-        onConnection.add(this.onConnection, this);
-        onDisconnection.add(this.onDisconnection, this);
+        apiHandler.onConnection.add(this.onConnection, this);
+        apiHandler.onDisconnection.add(this.onDisconnection, this);
     }
 
     public getAllChannels(): Channel[] {

--- a/src/provider/common/Injectables.ts
+++ b/src/provider/common/Injectables.ts
@@ -11,7 +11,8 @@ enum Injectable {
     ENVIRONMENT,
     INTENT_HANDLER,
     MODEL,
-    SELECTOR
+    SELECTOR,
+    CHANNEL_MODEL
 }
 
 type InjectableMap = {

--- a/src/provider/common/Injector.ts
+++ b/src/provider/common/Injector.ts
@@ -11,6 +11,7 @@ import {AsyncInit} from '../controller/AsyncInit';
 import {FinEnvironment} from '../model/Environment';
 import {APIHandler} from '../APIHandler';
 import {APIFromClientTopic} from '../../client/internal';
+import {ChannelModel} from '../ChannelModel';
 
 import {Inject} from './Injectables';
 
@@ -25,7 +26,8 @@ type Types = {
     [Inject.ENVIRONMENT]: Environment,
     [Inject.INTENT_HANDLER]: IntentHandler,
     [Inject.MODEL]: Model,
-    [Inject.SELECTOR]: SelectorHandler
+    [Inject.SELECTOR]: SelectorHandler,
+    [Inject.CHANNEL_MODEL]: ChannelModel
 };
 
 /**
@@ -41,7 +43,8 @@ const Bindings = {
     [Inject.ENVIRONMENT]: FinEnvironment,
     [Inject.INTENT_HANDLER]: IntentHandler,
     [Inject.MODEL]: Model,
-    [Inject.SELECTOR]: SelectorHandler
+    [Inject.SELECTOR]: SelectorHandler,
+    [Inject.CHANNEL_MODEL]: ChannelModel
 };
 
 type Keys = (keyof typeof Inject & keyof typeof Bindings & keyof Types);

--- a/src/provider/common/Injector.ts
+++ b/src/provider/common/Injector.ts
@@ -8,7 +8,7 @@ import {ContextHandler} from '../controller/ContextHandler';
 import {Model} from '../model/Model';
 import {SelectorHandler} from '../controller/SelectorHandler';
 import {AsyncInit} from '../controller/AsyncInit';
-import {FinEnvironment} from '../model/Environment';
+import {FinEnvironment} from '../model/implementation/Fin';
 import {APIHandler} from '../APIHandler';
 import {APIFromClientTopic} from '../../client/internal';
 import {ChannelModel} from '../ChannelModel';

--- a/src/provider/common/Injector.ts
+++ b/src/provider/common/Injector.ts
@@ -8,7 +8,7 @@ import {ContextHandler} from '../controller/ContextHandler';
 import {Model} from '../model/Model';
 import {SelectorHandler} from '../controller/SelectorHandler';
 import {AsyncInit} from '../controller/AsyncInit';
-import {FinEnvironment} from '../model/implementation/Fin';
+import {FinEnvironment} from '../model/FinEnvironment';
 import {APIHandler} from '../APIHandler';
 import {APIFromClientTopic} from '../../client/internal';
 import {ChannelModel} from '../ChannelModel';

--- a/src/provider/controller/ContextHandler.ts
+++ b/src/provider/controller/ContextHandler.ts
@@ -15,6 +15,7 @@ import {
     APIToClientTopic
 } from '../../client/internal';
 import {Inject} from '../common/Injectables';
+import {getId} from '../model/Model';
 
 @injectable()
 export class ContextHandler {
@@ -42,11 +43,11 @@ export class ContextHandler {
 
         this._channelModel.setContext(channel.id, context);
 
-        const sourceId = AppWindow.getId(source);
+        const sourceId = getId(source);
 
         await Promise.all(channelMembers
             // Sender window should not receive its own broadcasts
-            .filter(identity => AppWindow.getId(identity) !== sourceId)
+            .filter(identity => getId(identity) !== sourceId)
             .map(identity => this.send(identity, context)));
     }
 

--- a/src/provider/controller/ContextHandler.ts
+++ b/src/provider/controller/ContextHandler.ts
@@ -4,7 +4,7 @@ import {ProviderIdentity} from 'openfin/_v2/api/interappbus/channel/channel';
 
 import {AppWindow} from '../model/AppWindow';
 import {Context, ChannelChangedEvent, Channel} from '../../client/main';
-import {ChannelModel, createChannelModel} from '../ChannelModel';
+import {ChannelModel} from '../ChannelModel';
 import {APIHandler} from '../APIHandler';
 import {
     APIFromClientTopic,
@@ -21,9 +21,12 @@ export class ContextHandler {
     private _apiHandler: APIHandler<APIFromClientTopic>;
     private _channelModel: ChannelModel;
 
-    constructor(@inject(Inject.API_HANDLER) apiHandler: APIHandler<APIFromClientTopic>) {
+    constructor(
+        @inject(Inject.API_HANDLER) apiHandler: APIHandler<APIFromClientTopic>,
+        @inject(Inject.CHANNEL_MODEL) channelModel: ChannelModel
+    ) {
         this._apiHandler = apiHandler;
-        this._channelModel = createChannelModel(apiHandler.onConnection, apiHandler.onDisconnection);
+        this._channelModel = channelModel;
         this._channelModel.onChannelChanged.add(this.onChannelChangedHandler, this);
     }
 

--- a/src/provider/model/AppWindow.ts
+++ b/src/provider/model/AppWindow.ts
@@ -5,97 +5,32 @@ import {Signal1} from '../common/Signal';
 
 import {ContextChannel} from './ContextChannel';
 
-interface ContextSpec {
+export interface ContextSpec {
     type: string;
 }
 
-interface IntentMap {
-    [key: string]: boolean;
-}
-
-export const INTENT_LISTENER_TIMEOUT = 5000;
-
 /**
- * Model object, representing a window that has connected to the service.
+ * Model interface, representing a window that has connected to the service.
  *
  * Only windows that have created intent or context listeners will be represented in this model. If any non-registered
  * window.
  */
-export class AppWindow {
-    /**
-     * Generates a unique `string` id for a window based on its application's uuid and window name
-     * @param identity
-     */
-    public static getId(identity: Identity): string {
-        return `${identity.uuid}/${identity.name || identity.uuid}`;
-    }
+export interface AppWindow {
+    id: string;
 
-    private readonly _id: string;
-    private readonly _appInfo: Application;
-    private readonly _window: Window;
+    contexts: ReadonlyArray<ContextChannel>;
 
-    private readonly _intentListeners: IntentMap;
-    private readonly _contexts: ContextSpec[];
+    identity: Identity;
 
-    constructor(identity: Identity, appInfo: Application) {
-        this._id = AppWindow.getId(identity);
-        this._window = fin.Window.wrapSync(identity);
-        this._appInfo = appInfo;
+    appInfo: Readonly<Application>;
 
-        this._intentListeners = {};
-        this._contexts = [];
-    }
+    addIntentListener(intentName: string): void;
 
-    private readonly _onIntentListenerAdded: Signal1<IntentType> = new Signal1();
+    removeIntentListener(intentName: string): void;
 
-    public get id(): string {
-        return this._id;
-    }
+    hasAnyIntentListener(): boolean;
 
-    public get identity(): Identity {
-        return this._window.identity;
-    }
+    focus(): Promise<void>;
 
-    public get appInfo(): Readonly<Application> {
-        return this._appInfo;
-    }
-
-    public addIntentListener(intentName: string): void {
-        this._intentListeners[intentName] = true;
-        this._onIntentListenerAdded.emit(intentName);
-    }
-
-    public removeIntentListener(intentName: string): void {
-        delete this._intentListeners[intentName];
-    }
-
-    public hasAnyIntentListener() {
-        return Object.keys(this._intentListeners).length > 0;
-    }
-
-    public get contexts(): ReadonlyArray<ContextChannel> {
-        return this._contexts;
-    }
-
-    public focus(): Promise<void> {
-        return this._window.setAsForeground();
-    }
-
-    public ensureReadyToReceiveIntent(intent: IntentType): Promise<void> {
-        if (this._intentListeners[intent]) {
-            return Promise.resolve();
-        }
-        return new Promise((resolve, reject) => {
-            const slot = this._onIntentListenerAdded.add(intentAdded => {
-                if (intentAdded === intent) {
-                    slot.remove();
-                    resolve();
-                }
-            });
-            setTimeout(() => {
-                slot.remove();
-                reject(new Error(`Timeout waiting for intent listener to be added. intent = ${intent}`));
-            }, INTENT_LISTENER_TIMEOUT);
-        });
-    }
+    ensureReadyToReceiveIntent(intent: IntentType): Promise<void>;
 }

--- a/src/provider/model/Environment.ts
+++ b/src/provider/model/Environment.ts
@@ -1,9 +1,6 @@
-import {injectable} from 'inversify';
-import {WindowEvent} from 'openfin/_v2/api/events/base';
 import {Identity} from 'openfin/_v2/main';
 
 import {Signal1, Signal2} from '../common/Signal';
-import {AsyncInit} from '../controller/AsyncInit';
 import {Application} from '../../client/main';
 
 import {AppWindow} from './AppWindow';
@@ -21,57 +18,4 @@ export interface Environment {
      * Creates an `AppWindow` object for an existing window.
      */
     wrapApplication: (appInfo: Application, identity: Identity) => AppWindow;
-}
-
-@injectable()
-export class FinEnvironment extends AsyncInit implements Environment {
-    /**
-     * Indicates that a new window has been created.
-     *
-     * When the service first starts, this signal will also be fired for any pre-existing windows.
-     *
-     * Arguments: (identity: Identity, manifestUrl: string)
-     */
-    public readonly windowCreated: Signal2<Identity, string> = new Signal2();
-
-    /**
-     * Indicates that a window has been closed.
-     *
-     * Arguments: (identity: Identity)
-     */
-    public readonly windowClosed: Signal1<Identity> = new Signal1();
-
-    public async createApplication(appInfo: Application): Promise<AppWindow> {
-        const app = await fin.Application.startFromManifest(appInfo.manifest);
-        return new AppWindow(app.identity, appInfo);
-    }
-
-    public wrapApplication(appInfo: Application, identity: Identity): AppWindow {
-        return new AppWindow(identity, appInfo);
-    }
-
-    protected async init(): Promise<void> {
-        fin.System.addListener('window-created', (event: WindowEvent<'system', 'window-created'>) => {
-            const identity = {uuid: event.uuid, name: event.name};
-            this.registerWindow(identity);
-        });
-        fin.System.addListener('window-closed', (event: WindowEvent<'system', 'window-closed'>) => {
-            const identity = {uuid: event.uuid, name: event.name};
-            this.windowClosed.emit(identity);
-        });
-
-        // Register windows that were running before launching the FDC3 service
-        const windowInfo = await fin.System.getAllWindows();
-        windowInfo.forEach(info => {
-            const {uuid, mainWindow, childWindows} = info;
-
-            this.registerWindow({uuid, name: mainWindow.name});
-            childWindows.forEach(child => this.registerWindow({uuid, name: child.name}));
-        });
-    }
-
-    private async registerWindow(identity: Identity): Promise<void> {
-        const info = await fin.Application.wrapSync(identity).getInfo();
-        this.windowCreated.emit(identity, info.manifestUrl);
-    }
 }

--- a/src/provider/model/FinEnvironment.ts
+++ b/src/provider/model/FinEnvironment.ts
@@ -2,13 +2,14 @@ import {WindowEvent} from 'openfin/_v2/api/events/base';
 import {injectable} from 'inversify';
 import {Identity, Window} from 'openfin/_v2/main';
 
-import {AsyncInit} from '../../controller/AsyncInit';
-import {Environment} from '../Environment';
-import {Signal1, Signal2} from '../../common/Signal';
-import {Application, IntentType} from '../../../client/main';
-import {AppWindow, ContextSpec} from '../AppWindow';
-import {ContextChannel} from '../ContextChannel';
-import {getId} from '../Model';
+import {AsyncInit} from '../controller/AsyncInit';
+import {Signal1, Signal2} from '../common/Signal';
+import {Application, IntentType} from '../../client/main';
+
+import {Environment} from './Environment';
+import {AppWindow, ContextSpec} from './AppWindow';
+import {ContextChannel} from './ContextChannel';
+import {getId} from './Model';
 
 export const INTENT_LISTENER_TIMEOUT = 5000;
 

--- a/src/provider/model/Model.ts
+++ b/src/provider/model/Model.ts
@@ -20,6 +20,14 @@ export interface FindOptions {
     require?: FindFilter;
 }
 
+/**
+ * Generates a unique `string` id for a window based on its application's uuid and window name
+ * @param identity
+ */
+export function getId(identity: Identity): string {
+    return `${identity.uuid}/${identity.name || identity.uuid}`;
+}
+
 @injectable()
 export class Model {
     @inject(Inject.APP_DIRECTORY)
@@ -49,7 +57,7 @@ export class Model {
     }
 
     public getWindow(identity: Identity): AppWindow|null {
-        return this._windows.find(w => w.id === AppWindow.getId(identity)) || null;
+        return this._windows.find(w => w.id === getId(identity)) || null;
     }
 
     public findWindow(appInfo: Application, options?: FindOptions): AppWindow|null {
@@ -105,7 +113,7 @@ export class Model {
         const appInfo = apps.find(app => app.manifest.startsWith(manifestUrl));
 
         if (appInfo) {
-            const id: string = AppWindow.getId(identity);
+            const id: string = getId(identity);
 
             if (!this._windows.some(window => window.id === id)) {
                 console.info(`Registering window ${id}`);
@@ -119,7 +127,7 @@ export class Model {
     }
 
     private onWindowClosed(identity: Identity): void {
-        const id: string = AppWindow.getId(identity);
+        const id: string = getId(identity);
         const index = this._windows.findIndex(window => window.id === id);
 
         if (index >= 0) {

--- a/src/provider/model/implementation/Fin.ts
+++ b/src/provider/model/implementation/Fin.ts
@@ -1,0 +1,142 @@
+import {WindowEvent} from 'openfin/_v2/api/events/base';
+import {injectable} from 'inversify';
+import {Identity, Window} from 'openfin/_v2/main';
+
+import {AsyncInit} from '../../controller/AsyncInit';
+import {Environment} from '../Environment';
+import {Signal1, Signal2} from '../../common/Signal';
+import {Application, IntentType} from '../../../client/main';
+import {AppWindow, ContextSpec} from '../AppWindow';
+import {ContextChannel} from '../ContextChannel';
+import {getId} from '../Model';
+
+export const INTENT_LISTENER_TIMEOUT = 5000;
+
+@injectable()
+export class FinEnvironment extends AsyncInit implements Environment {
+    /**
+     * Indicates that a new window has been created.
+     *
+     * When the service first starts, this signal will also be fired for any pre-existing windows.
+     *
+     * Arguments: (identity: Identity, manifestUrl: string)
+     */
+    public readonly windowCreated: Signal2<Identity, string> = new Signal2();
+
+    /**
+     * Indicates that a window has been closed.
+     *
+     * Arguments: (identity: Identity)
+     */
+    public readonly windowClosed: Signal1<Identity> = new Signal1();
+
+    public async createApplication(appInfo: Application): Promise<AppWindow> {
+        const app = await fin.Application.startFromManifest(appInfo.manifest);
+        return new FinAppWindow(app.identity, appInfo);
+    }
+
+    public wrapApplication(appInfo: Application, identity: Identity): AppWindow {
+        return new FinAppWindow(identity, appInfo);
+    }
+
+    protected async init(): Promise<void> {
+        fin.System.addListener('window-created', (event: WindowEvent<'system', 'window-created'>) => {
+            const identity = {uuid: event.uuid, name: event.name};
+            this.registerWindow(identity);
+        });
+        fin.System.addListener('window-closed', (event: WindowEvent<'system', 'window-closed'>) => {
+            const identity = {uuid: event.uuid, name: event.name};
+            this.windowClosed.emit(identity);
+        });
+
+        // Register windows that were running before launching the FDC3 service
+        const windowInfo = await fin.System.getAllWindows();
+        windowInfo.forEach(info => {
+            const {uuid, mainWindow, childWindows} = info;
+
+            this.registerWindow({uuid, name: mainWindow.name});
+            childWindows.forEach(child => this.registerWindow({uuid, name: child.name}));
+        });
+    }
+
+    private async registerWindow(identity: Identity): Promise<void> {
+        const info = await fin.Application.wrapSync(identity).getInfo();
+        this.windowCreated.emit(identity, info.manifestUrl);
+    }
+}
+
+interface IntentMap {
+    [key: string]: boolean;
+}
+
+class FinAppWindow {
+    private readonly _id: string;
+    private readonly _appInfo: Application;
+    private readonly _window: Window;
+
+    private readonly _intentListeners: IntentMap;
+    private readonly _contexts: ContextSpec[];
+
+    constructor(identity: Identity, appInfo: Application) {
+        this._id = getId(identity);
+        this._window = fin.Window.wrapSync(identity);
+        this._appInfo = appInfo;
+
+        this._intentListeners = {};
+        this._contexts = [];
+    }
+
+    private readonly _onIntentListenerAdded: Signal1<IntentType> = new Signal1();
+
+    public get id(): string {
+        return this._id;
+    }
+
+    public get identity(): Identity {
+        return this._window.identity;
+    }
+
+    public get appInfo(): Readonly<Application> {
+        return this._appInfo;
+    }
+
+    public get contexts(): ReadonlyArray<ContextChannel> {
+        return this._contexts;
+    }
+
+    public addIntentListener(intentName: string): void {
+        this._intentListeners[intentName] = true;
+        this._onIntentListenerAdded.emit(intentName);
+    }
+
+    public removeIntentListener(intentName: string): void {
+        delete this._intentListeners[intentName];
+    }
+
+    public hasAnyIntentListener() {
+        return Object.keys(this._intentListeners).length > 0;
+    }
+
+    public focus(): Promise<void> {
+        return this._window.setAsForeground();
+    }
+
+    public ensureReadyToReceiveIntent(intent: IntentType): Promise<void> {
+        if (this._intentListeners[intent]) {
+            return Promise.resolve();
+        }
+        return new Promise((resolve, reject) => {
+            const slot = this._onIntentListenerAdded.add(intentAdded => {
+                if (intentAdded === intent) {
+                    slot.remove();
+                    resolve();
+                }
+            });
+            setTimeout(() => {
+                slot.remove();
+                reject(new Error(`Timeout waiting for intent listener to be added. intent = ${intent}`));
+            }, INTENT_LISTENER_TIMEOUT);
+        });
+    }
+}
+

--- a/test/demo/raiseIntent.test.ts
+++ b/test/demo/raiseIntent.test.ts
@@ -1,7 +1,7 @@
 import 'jest';
 
-import {INTENT_LISTENER_TIMEOUT} from '../../src/provider/model/AppWindow';
 import {ResolveError} from '../../src/client/errors';
+import {INTENT_LISTENER_TIMEOUT} from '../../src/provider/model/implementation/Fin';
 
 import {fin} from './utils/fin';
 import * as fdc3Remote from './utils/fdc3RemoteExecution';

--- a/test/demo/raiseIntent.test.ts
+++ b/test/demo/raiseIntent.test.ts
@@ -1,4 +1,5 @@
 import 'jest';
+import 'reflect-metadata';
 
 import {ResolveError} from '../../src/client/errors';
 import {INTENT_LISTENER_TIMEOUT} from '../../src/provider/model/FinEnvironment';

--- a/test/demo/raiseIntent.test.ts
+++ b/test/demo/raiseIntent.test.ts
@@ -1,7 +1,7 @@
 import 'jest';
 
 import {ResolveError} from '../../src/client/errors';
-import {INTENT_LISTENER_TIMEOUT} from '../../src/provider/model/implementation/Fin';
+import {INTENT_LISTENER_TIMEOUT} from '../../src/provider/model/FinEnvironment';
 
 import {fin} from './utils/fin';
 import * as fdc3Remote from './utils/fdc3RemoteExecution';

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,0 +1,19 @@
+import {AppWindow} from '../src/provider/model/AppWindow';
+import {IntentType} from '../src/client/main';
+
+/**
+ * Creates a minimal mock app window. Any utilizing test should set properties and set up mock functions as needed
+ */
+export function createMockAppWindow(): AppWindow {
+    return {
+        id: '',
+        identity: {name: '', uuid: ''},
+        appInfo: {appId: '', name: '', manifest: '', manifestType: ''},
+        contexts: [],
+        addIntentListener: jest.fn<void, [string]>(),
+        removeIntentListener: jest.fn<void, [string]>(),
+        hasAnyIntentListener: jest.fn<boolean, []>(),
+        focus: jest.fn<Promise<void>, []>(),
+        ensureReadyToReceiveIntent: jest.fn<Promise<void>, [IntentType]>()
+    };
+}

--- a/test/provider/AppDirectory.unittest.ts
+++ b/test/provider/AppDirectory.unittest.ts
@@ -4,7 +4,6 @@ import 'reflect-metadata';
 import {AppDirectory} from '../../src/provider/model/AppDirectory';
 import {Application} from '../../src/client/directory';
 import {AppIntent} from '../../src/client/main';
-import {delay} from '../demo/utils/delay';
 
 enum StorageKeys {
     URL = 'fdc3@url',

--- a/test/provider/ContextHandler.unittest.ts
+++ b/test/provider/ContextHandler.unittest.ts
@@ -1,0 +1,90 @@
+import 'reflect-metadata';
+
+import {Identity} from 'openfin/_v2/main';
+
+import {ContextHandler} from '../../src/provider/controller/ContextHandler';
+import {APIHandler} from '../../src/provider/APIHandler';
+import {ChannelModel} from '../../src/provider/ChannelModel';
+import {Signal1} from '../../src/provider/common/Signal';
+import {ChannelChangedEvent, ChannelId, Channel} from '../../src/client/main';
+import {AppWindow} from '../../src/provider/model/AppWindow';
+import {APIFromClientTopic, APIToClientTopic} from '../../src/client/internal';
+import {createMockAppWindow} from '../mocks';
+
+jest.mock('../../src/provider/APIHandler');
+jest.mock('../../src/provider/ChannelModel');
+
+const testContext = {type: 'test-context-payload'};
+const mockDispatch: jest.Mock<Promise<any>, [Identity, string, any]> = jest.fn<Promise<any>, [Identity, string, any]>();
+
+let contextHandler: ContextHandler;
+let mockGetChannelMembers: jest.Mock<Identity[], [ChannelId]>;
+
+function createMockAppWindowWithName(name: string): AppWindow {
+    const mockAppWindow: AppWindow = createMockAppWindow();
+    mockAppWindow.identity = {uuid: 'test', name};
+
+    return mockAppWindow;
+}
+
+function setChannelModelToProvideWindows(...windows: AppWindow[]): void {
+    mockGetChannelMembers.mockImplementation(() => {
+        return windows.map(window => (window.identity));
+    });
+}
+
+beforeEach(() => {
+    jest.resetAllMocks();
+
+    const mockApiHandler = new APIHandler<APIFromClientTopic>();
+    // Set up channel.dispatch on our mock APIHandler so we can spy on it
+    (mockApiHandler as any)['channel'] = {dispatch: mockDispatch};
+
+    const mockChannelModel = new ChannelModel(null!);
+    // Modify default mock ChannelModel just enough to let ContextHandler work
+    (mockChannelModel.getChannel as jest.Mock<Channel, [Identity]>).mockImplementation((identity: Identity) => {
+        return {id: 'test', type: 'user', name: 'test', color: 0};
+    });
+    (mockChannelModel as any)['onChannelChanged'] = new Signal1<ChannelChangedEvent>();
+    // Grab getChannelMembers so we can control its result for each test
+    mockGetChannelMembers = mockChannelModel.getChannelMembers as jest.Mock<Identity[], [ChannelId]>;
+
+    contextHandler = new ContextHandler(mockApiHandler, mockChannelModel);
+});
+
+describe('When sending a Context using ContextHandler', () => {
+    it('The provided Context is dispatched to the expected target', async () => {
+        const targetAppWindow = createMockAppWindowWithName('target');
+
+        await contextHandler.send(targetAppWindow, testContext);
+
+        expect(mockDispatch).toBeCalledWith(targetAppWindow.identity, APIToClientTopic.CONTEXT, testContext);
+    });
+});
+
+describe('When broadcasting a Context using ContextHandler', () => {
+    it('When ContextModel provides only the source window, the Context is not dispatched', async () => {
+        const sourceAppWindow = createMockAppWindowWithName('source');
+
+        setChannelModelToProvideWindows(sourceAppWindow);
+
+        await contextHandler.broadcast(testContext, sourceAppWindow.identity);
+
+        expect(mockDispatch).toBeCalledTimes(0);
+    });
+
+    it('When ContextModel provides multiple windows, all windows except the source window are dispatched to', async () => {
+        const sourceAppWindow = createMockAppWindowWithName('source');
+        const targetAppWindow1 = createMockAppWindowWithName('target-1');
+        const targetAppWindow2 = createMockAppWindowWithName('target-2');
+
+        setChannelModelToProvideWindows(sourceAppWindow, targetAppWindow1, targetAppWindow2);
+
+        await contextHandler.broadcast(testContext, sourceAppWindow.identity);
+
+        expect(mockDispatch).toBeCalledTimes(2);
+
+        expect(mockDispatch.mock.calls).toContainEqual([targetAppWindow1.identity, APIToClientTopic.CONTEXT, testContext]);
+        expect(mockDispatch.mock.calls).toContainEqual([targetAppWindow2.identity, APIToClientTopic.CONTEXT, testContext]);
+    });
+});


### PR DESCRIPTION
- Separates `AppWindow` into an interface and its `FinAppWindow` implementation. I've put it in `FinEnvironment` so that it doesn't need to be exported. Feels like it's an implementation detail of `FinEnvironment`, so shouldn't be visible elsewhere

- Adds unit tests around `ContextHandler`

- Fixes some circular dependencies, and on-import references to `fin` that were causing problems when running things in Jest

- Still need to do a review to see if this fully completes the story, but think this is worth getting in as a chunk on its own