### PR TITLE
[N/A] Fix test timeouts on Jenkins

### DIFF
--- a/jest-int.config.json
+++ b/jest-int.config.json
@@ -20,6 +20,7 @@
     "globalSetup": "./demo/utils/globalSetup.ts",
     "globalTeardown": "./demo/utils/globalTeardown.ts",
     "testEnvironment": "./demo/utils/integrationTestEnv.js",
+    "setupFilesAfterEnv": ["./demo/utils/integrationSetupAfterEnv.js"],
     "reporters": [
       "default",
       [

--- a/test/demo/constants.ts
+++ b/test/demo/constants.ts
@@ -1,0 +1,1 @@
+export const appStartupTime = 15000;

--- a/test/demo/constants.ts
+++ b/test/demo/constants.ts
@@ -1,1 +1,1 @@
-export const appStartupTime = 15000;
+export const appStartupTime = 30 * 1000;

--- a/test/demo/contextChannels.test.ts
+++ b/test/demo/contextChannels.test.ts
@@ -2,6 +2,7 @@ import 'jest';
 import {connect, Fin, Identity, Application} from 'hadouken-js-adapter';
 
 import * as fdc3Remote from './utils/fdc3RemoteExecution';
+import {appStartupTime} from './constants';
 
 const testManagerIdentity = {uuid: 'test-app', name: 'test-app'};
 
@@ -34,9 +35,6 @@ async function setupWindows(...channels: (string|undefined)[]): Promise<Identity
     const app4 = {uuid: 'test-app-4', name: 'test-app-4'};
 
     const appIdentities = [app1, app2, app3, app4];
-
-    // Creating apps takes time, so increase timeout
-    jest.setTimeout(channels.length * 5000);
 
     const result: Identity[] = await Promise.all(channels.map(async (channel, index) => {
         const identity = appIdentities[index];
@@ -74,7 +72,7 @@ describe('When broadcasting on global channel', () => {
         // Check the blue window received no context
         const blueContexts = await blueListener.getReceivedContexts();
         expect(blueContexts).toHaveLength(0);
-    });
+    }, appStartupTime * 2);
 
     it('Context is received by window that has left and rejoined global channel', async () => {
         const [channelChangingWindow] = await setupWindows('blue');
@@ -114,7 +112,7 @@ describe('When broadcasting on a user channel', () => {
         // Check our blue window received no context
         const blueReceivedContexts = await blueListener.getReceivedContexts();
         expect(blueReceivedContexts).toHaveLength(0);
-    });
+    }, appStartupTime * 4);
 
     it('Context is received by window that has left and rejoined user channel', async () => {
         const [blueWindow, channelChangingWindow] = await setupWindows('blue', undefined);
@@ -131,7 +129,7 @@ describe('When broadcasting on a user channel', () => {
         // Check our blue window received our test context
         const receivedContexts = await channelChangingWindowListener.getReceivedContexts();
         expect(receivedContexts).toEqual([testContext]);
-    });
+    }, appStartupTime * 2);
 });
 
 describe('When joining a channel', () => {
@@ -197,7 +195,7 @@ describe('When joining a channel', () => {
         // Check our now-yellow window received our test context
         const receivedContexts = await channelChangingListener.getReceivedContexts();
         expect(receivedContexts).toEqual([testContext]);
-    });
+    }, appStartupTime * 2);
 
     it('Window does not receive cached context for global channel', async () => {
         const [channelChangingWindow] = await setupWindows('red');

--- a/test/demo/raiseIntent.test.ts
+++ b/test/demo/raiseIntent.test.ts
@@ -6,6 +6,7 @@ import {ResolveError} from '../../src/client/errors';
 import {fin} from './utils/fin';
 import * as fdc3Remote from './utils/fdc3RemoteExecution';
 import {delay} from './utils/delay';
+import {appStartupTime} from './constants';
 
 const testManagerIdentity = {
     uuid: 'test-app',
@@ -169,7 +170,12 @@ describe('Intent listeners and raising intents', () => {
                         testAppIdentity.appId
                     );
 
-                    await delay(1500);
+                    const testApp = fin.Application.wrapSync({uuid: 'test-app-1', name: 'test-app-1'});
+
+                    while (!await testApp.isRunning()) {
+                        await delay(500);
+                    }
+
                     // App should now be running
                     await expect(fin.Application.wrapSync(testAppIdentity).isRunning()).resolves.toBe(true);
 
@@ -187,7 +193,7 @@ describe('Intent listeners and raising intents', () => {
                     expect(receivedContexts).toEqual([validPayload.context]);
 
                     await fin.Application.wrapSync(testAppIdentity).quit();
-                });
+                }, appStartupTime + 1500);
             });
         });
     });

--- a/test/demo/utils/integrationSetupAfterEnv.js
+++ b/test/demo/utils/integrationSetupAfterEnv.js
@@ -1,0 +1,1 @@
+jest.setTimeout(30 * 1000);


### PR DESCRIPTION
Apps will generally take 3-5 seconds to startup on Jenkins (locally they take 1-2 seconds, and the Jest default time out is 5 seconds). Sometimes on Jenkins, apps will take 20+ seconds to start.

This changes the test timeouts to accommodate this, and makes the necessary changes to raiseIntent.test given we can't guarantee a 'quick' app startup time

Aware this will conflict when we pull in develop, given unification of service tests in develop