### PR TITLE
[N/A] Fixed upload of runtime channel manifests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ def deployToS3() {
     sh "aws s3 cp ./dist/docs ${DIR_DOCS_VERSION} --recursive"
 
     sh "aws s3 cp ./dist/provider/app.json ${DIR_BUILD_ROOT}${MANIFEST_NAME}"
-    sh "aws s3 cp ./dist/provider/ ${DIR_BUILD_ROOT} --exclude \"*\" --include \"app.runtime-*.json\""
+    sh "aws s3 cp ./dist/provider/ ${DIR_BUILD_ROOT} --recursive --exclude \"*\" --include \"app.runtime-*.json\""
 }
 
 def deployToNPM() {


### PR DESCRIPTION
Upload of `app.runtime-*.json` manifests wasn't working due to missing `aws` argument.