### PR TITLE
[N/A] Updated demo apps to consistently use the 'fdc3.' prefix on context names

### DIFF
--- a/res/test/sample-app-directory.json
+++ b/res/test/sample-app-directory.json
@@ -23,7 +23,7 @@
         {
             "name": "DialCall",
             "displayName": "Dial",
-            "contexts": ["contact"],
+            "contexts": ["fdc3.contact"],
             "customConfig": {
                 "icon": "fa-tty"
             }

--- a/src/demo/apps/ChartsApp.tsx
+++ b/src/demo/apps/ChartsApp.tsx
@@ -38,7 +38,7 @@ export function ChartsApp(props: AppProps): React.ReactElement {
         });
 
         const contextListener = fdc3.addContextListener((context: Context): void => {
-            if (context.type === 'security') {
+            if (context.type === 'fdc3.security') {
                 handleIntent(context as SecurityContext);
             }
         });

--- a/src/demo/apps/NewsApp.tsx
+++ b/src/demo/apps/NewsApp.tsx
@@ -34,7 +34,7 @@ export function NewsApp(): React.ReactElement {
         });
 
         const contextListener = fdc3.addContextListener((context: Context): void => {
-            if (context.type === 'security') {
+            if (context.type === 'fdc3.security') {
                 handleIntent(context as SecurityContext);
             }
         });

--- a/src/demo/components/blotter/SymbolsRow.tsx
+++ b/src/demo/components/blotter/SymbolsRow.tsx
@@ -81,7 +81,7 @@ export function SymbolsRow(props: SymbolsRowProps): React.ReactElement {
 
     const getContext = () => {
         return {
-            type: 'security',
+            type: 'fdc3.security',
             name: item.name,
             id: {
                 default: item.name

--- a/test/demo/findIntentsByContext.inttest.ts
+++ b/test/demo/findIntentsByContext.inttest.ts
@@ -40,7 +40,7 @@ describe('Resolving intents by context, findIntentsByContext', () => {
 
     describe('When calling findIntentsByContext with a context type accepted by some directory app', () => {
         const contactContext = {
-            type: 'contact',
+            type: 'fdc3.contact',
             name: 'Test Name'
         };
         test('The promise resolves to an array of all compatible AppIntents', async () => {


### PR DESCRIPTION
Minor string change(s) in demo app. Was spotted with .NET client testing, which was using FDC3-compliant type names.

Have only updated the demo apps, context types in tests remain as before.