### PR TITLE
[SERVICE-612] Update FDC3 demo apps to use correct context type

### DIFF
--- a/src/client/context.ts
+++ b/src/client/context.ts
@@ -46,9 +46,14 @@ export interface ContactContext extends Context {
     name: string;
     id: {[key: string]: string}&{email?: string; twitter?: string; phone?: string};
 }
-export interface SecurityContext extends Context {
-    type: 'fdc3.security';
-    id: {[key: string]: string}&{default: string};
+export interface InstrumentContext extends Context {
+    type: 'fdc3.instrument';
+    name: string;
+    id: {
+        ticker?: string;
+        ISIN?: string;
+        CUSIP?: string;
+    }
 }
 export interface OrganizationContext extends Context {
     type: 'fdc3.organization';

--- a/src/demo/apps/ChartsApp.tsx
+++ b/src/demo/apps/ChartsApp.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import * as fdc3 from '../../client/main';
 import {Chart} from '../components/charts/Chart';
-import {SecurityContext, Context} from '../../client/context';
+import {InstrumentContext, Context} from '../../client/context';
 import '../../../res/demo/css/w3.css';
 import {ContextChannelSelector} from '../components/ContextChannelSelector/ContextChannelSelector';
 import {getCurrentChannel} from '../../client/main';
@@ -14,7 +14,7 @@ interface AppProps {
 export function ChartsApp(props: AppProps): React.ReactElement {
     const [symbolName, setSymbolName] = React.useState('AAPL');
 
-    function handleIntent(context: SecurityContext): void {
+    function handleIntent(context: InstrumentContext): void {
         if (context && context.name) {
             setSymbolName(context.name);
         } else {
@@ -29,14 +29,14 @@ export function ChartsApp(props: AppProps): React.ReactElement {
     React.useEffect(() => {
         getCurrentChannel().then(async channel => {
             const context = await channel.getCurrentContext();
-            if (context && context.type === 'fdc3.security') {
-                handleIntent(context as SecurityContext);
+            if (context && context.type === 'fdc3.instrument') {
+                handleIntent(context as InstrumentContext);
             }
         });
         const intentListener = fdc3.addIntentListener(fdc3.Intents.VIEW_CHART, (context: Context): Promise<void> => {
             return new Promise((resolve, reject) => {
                 try {
-                    handleIntent(context as SecurityContext);
+                    handleIntent(context as InstrumentContext);
                     resolve();
                 } catch (e) {
                     reject(e);
@@ -45,8 +45,8 @@ export function ChartsApp(props: AppProps): React.ReactElement {
         });
 
         const contextListener = fdc3.addContextListener((context: Context): void => {
-            if (context.type === 'fdc3.security') {
-                handleIntent(context as SecurityContext);
+            if (context.type === 'fdc3.instrument') {
+                handleIntent(context as InstrumentContext);
             }
         });
 

--- a/src/demo/apps/NewsApp.tsx
+++ b/src/demo/apps/NewsApp.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import * as fdc3 from '../../client/main';
 import {NewsFeed} from '../components/news/NewsFeed';
-import {SecurityContext, Context} from '../../client/context';
+import {InstrumentContext, Context} from '../../client/context';
 import '../../../res/demo/css/w3.css';
 import {ContextChannelSelector} from '../components/ContextChannelSelector/ContextChannelSelector';
 import {getCurrentChannel} from '../../client/main';
@@ -10,7 +10,7 @@ import {getCurrentChannel} from '../../client/main';
 export function NewsApp(): React.ReactElement {
     const [symbolName, setSymbolName] = React.useState('AAPL');
 
-    function handleIntent(context: SecurityContext): void {
+    function handleIntent(context: InstrumentContext): void {
         if (context && context.name) {
             setSymbolName(context.name);
         } else {
@@ -26,14 +26,14 @@ export function NewsApp(): React.ReactElement {
         getCurrentChannel().then(async channel => {
             const context = await channel.getCurrentContext();
             if (context && context.type === 'security') {
-                handleIntent(context as SecurityContext);
+                handleIntent(context as InstrumentContext);
             }
         });
 
         const intentListener = fdc3.addIntentListener(fdc3.Intents.VIEW_NEWS, (context: Context): Promise<void> => {
             return new Promise((resolve, reject) => {
                 try {
-                    handleIntent(context as SecurityContext);
+                    handleIntent(context as InstrumentContext);
                     resolve();
                 } catch (e) {
                     reject(e);
@@ -42,8 +42,8 @@ export function NewsApp(): React.ReactElement {
         });
 
         const contextListener = fdc3.addContextListener((context: Context): void => {
-            if (context.type === 'fdc3.security') {
-                handleIntent(context as SecurityContext);
+            if (context.type === 'fdc3.instrument') {
+                handleIntent(context as InstrumentContext);
             }
         });
 

--- a/src/demo/apps/NewsApp.tsx
+++ b/src/demo/apps/NewsApp.tsx
@@ -25,7 +25,7 @@ export function NewsApp(): React.ReactElement {
     React.useEffect(() => {
         getCurrentChannel().then(async channel => {
             const context = await channel.getCurrentContext();
-            if (context && context.type === 'security') {
+            if (context && context.type === 'fdc3.instrument') {
                 handleIntent(context as InstrumentContext);
             }
         });

--- a/src/demo/components/blotter/SymbolsRow.tsx
+++ b/src/demo/components/blotter/SymbolsRow.tsx
@@ -80,7 +80,7 @@ export function SymbolsRow(props: SymbolsRowProps): React.ReactElement {
 
     const getContext = () => {
         return {
-            type: 'fdc3.security',
+            type: 'fdc3.instrument',
             name: item.name,
             id: {
                 default: item.name


### PR DESCRIPTION
Changes all uses of old `SecurityContext` type to the new `InstrumentContext` type from the [FDC3 example doc](https://fdc3.finos.org/docs/1.0/context-intro#example-context-object).