### PR TITLE
[N/A] Removing public app directroy fallback

### DIFF
--- a/res/provider/config/fdc3-config.schema.json
+++ b/res/provider/config/fdc3-config.schema.json
@@ -132,7 +132,7 @@
             "properties": {
                 "applicationDirectory": {
                     "type": "string",
-                    "default": "https://app-directory.openfin.co/api/v1/apps/",
+                    "default": "",
                     "description": "The default location of the application directory"
                 }
             },


### PR DESCRIPTION
Temporarily removing fallback to public app directory, due to issues caused in the provider by the directory not currently being FDC3-compliant.

Public app directory will be re-added after next directory update. Change has no impact on the demo app running locally.