### PR TITLE
[SERVICE-578] The FDC3 service respects the optional context field on the findIntents call

### DIFF
--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -128,7 +128,7 @@ export class Main {
     private async findIntent(payload: FindIntentPayload): Promise<AppIntent> {
         let apps: Application[];
         if (payload.intent) {
-            apps = await this._model.getApplicationsForIntent(payload.intent);
+            apps = await this._model.getApplicationsForIntent(payload.intent, payload.context && parseContext(payload.context).type);
         } else {
             // This is a non-FDC3 workaround to get all directory apps by calling `findIntent` with a falsy intent.
             // Ideally the FDC3 spec would expose an API to access the directory in a more meaningful way

--- a/src/provider/model/AppDirectory.ts
+++ b/src/provider/model/AppDirectory.ts
@@ -35,9 +35,13 @@ export class AppDirectory extends AsyncInit {
         }) || null;
     }
 
-    public async getAppsByIntent(intentType: string): Promise<Application[]> {
+    public async getAppsByIntent(intentType: string, contextType?: string): Promise<Application[]> {
         return this._directory.filter((app: Application) => {
-            return app.intents && app.intents.some(intent => intent.name === intentType);
+            return app.intents && app.intents.some(intent => {
+                return intent.name === intentType && contextType ? intent.contexts.some(context => {
+                    return context === contextType;
+                }) : true;
+            });
         });
     }
 

--- a/src/provider/model/AppDirectory.ts
+++ b/src/provider/model/AppDirectory.ts
@@ -38,7 +38,7 @@ export class AppDirectory extends AsyncInit {
     public async getAppsByIntent(intentType: string, contextType?: string): Promise<Application[]> {
         return this._directory.filter((app: Application) => {
             return app.intents && app.intents.some(intent => {
-                return intent.name === intentType && contextType ? intent.contexts.some(context => {
+                return intent.name === intentType && (contextType && intent.contexts.length > 0) ? intent.contexts.some(context => {
                     return context === contextType;
                 }) : true;
             });


### PR DESCRIPTION
The optional context parameter in findIntents call in the FDC3 now filter out the apps that satisfy the specified intent type but not the context. 

If a context is specified, the non-directory apps will not be included as there is no way to know the intent context info of these app in provider at the moment.