### PR TITLE
[SERVICE-599] Verify proposed "Channel Restoration" flows

### DIFF
--- a/src/demo/components/ContextChannelSelector/ContextChannelSelector.tsx
+++ b/src/demo/components/ContextChannelSelector/ContextChannelSelector.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
-import {Channel, defaultChannel, getCurrentChannel, getSystemChannels, SystemChannel} from '../../../client/contextChannels';
+import {Channel, defaultChannel, getCurrentChannel, getSystemChannels, ChannelChangedEvent} from '../../../client/contextChannels';
+import {addEventListener, removeEventListener} from '../../../client/main';
+import {getId} from '../../../provider/model/Model';
 
 import {ContextChannelView} from './ChannelMemberView';
 
@@ -28,7 +30,18 @@ export function ContextChannelSelector(props: ContextChannelSelectorProps): Reac
         getSystemChannels().then(channels => {
             setChannels([defaultChannel, ...channels]);
         });
+        addEventListener('channel-changed', channelChanged);
+
+        return () => {
+            removeEventListener('channel-changed', channelChanged);
+        };
     }, []);
+
+    const channelChanged = (event: ChannelChangedEvent) => {
+        if (getId(event.identity) === getId(fin.Window.me) && event.channel !== currentChannel) {
+            setCurrentChannel(event.channel!);
+        }
+    };
 
     const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
         const {value: id} = event.currentTarget;

--- a/src/provider/constants.ts
+++ b/src/provider/constants.ts
@@ -15,7 +15,7 @@ export const Timeouts = {
     /**
      * Time service allows for a `window-created` event after a client expects the window to exist
      */
-    WINDOW_EXPECT_TO_SEEN: 100,
+    WINDOW_EXPECT_TO_SEEN: 250,
 
     /**
      * Time service allows for a window to go from first seen to being fully registered with the model

--- a/test/demo/expect.inttest.ts
+++ b/test/demo/expect.inttest.ts
@@ -44,7 +44,7 @@ afterEach(async () => {
     await fin.Application.wrapSync(testAppNotInDirectory1).quit(true);
 });
 
-test('When starting an app from a manifest, the app can be interacted with as soon as a `window-create` event is received', async () => {
+test('When starting an app, the app can be interacted with as soon as a `window-created` event is received', async () => {
     const startPromise = fin.Application.startFromManifest(testAppNotInDirectory1.manifestUrl);
 
     await channelJoinedPromise.promise;

--- a/test/demo/expect.inttest.ts
+++ b/test/demo/expect.inttest.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata';
+import {WindowEvent} from 'openfin/_v2/api/events/base';
+
+import {DeferredPromise} from '../../src/provider/common/DeferredPromise';
+import {getId} from '../../src/provider/model/Model';
+
+import {testAppNotInDirectory1, appStartupTime, testManagerIdentity} from './constants';
+import {setupTeardown} from './utils/common';
+import * as fdc3Remote from './utils/fdc3RemoteExecution';
+import {RemoteChannel} from './utils/RemoteChannel';
+import {fin} from './utils/fin';
+
+type WindowCreatedEvent = WindowEvent<'system', 'window-created'>;
+
+setupTeardown();
+
+let targetChannel: RemoteChannel;
+let channelJoinedPromise: DeferredPromise;
+let windowCreatedHandler: (event: WindowCreatedEvent) => void;
+
+beforeAll(async () => {
+    targetChannel = await fdc3Remote.getChannelById(testManagerIdentity, 'green');
+
+    windowCreatedHandler = (event: WindowCreatedEvent) => {
+        if (getId(event) === getId(testAppNotInDirectory1)) {
+            targetChannel.join(testAppNotInDirectory1).then(() => {
+                channelJoinedPromise.resolve();
+            });
+        }
+    };
+
+    await fin.System.addListener('window-created', windowCreatedHandler);
+});
+
+afterAll(async () => {
+    await fin.System.removeListener('window-created', windowCreatedHandler);
+});
+
+beforeEach(async () => {
+    channelJoinedPromise = new DeferredPromise();
+});
+
+afterEach(async () => {
+    await fin.Application.wrapSync(testAppNotInDirectory1).quit(true);
+});
+
+test('When starting an app from a manifest, the app can be interacted with as soon as a `window-create` event is received', async () => {
+    const startPromise = fin.Application.startFromManifest(testAppNotInDirectory1.manifestUrl);
+
+    await channelJoinedPromise.promise;
+
+    await expect(fdc3Remote.getCurrentChannel(testManagerIdentity, testAppNotInDirectory1)).resolves.toBe(targetChannel);
+
+    await startPromise;
+}, appStartupTime);

--- a/test/provider/expect.unittest.ts
+++ b/test/provider/expect.unittest.ts
@@ -51,7 +51,7 @@ type TestParam = [
 const FAKE_TEST_DURATION = 10000;
 
 const REGISTRATION_TIMEOUT = 5000;
-const PENDING_TIMEOUT = 100;
+const PENDING_TIMEOUT = 250;
 
 let model: Model;
 


### PR DESCRIPTION
This PR:
- Bumps up the `WINDOW_EXPECT_TO_SEEN` timeout (just over 100 seen in testing, so going 100 -> 250 this seems safe)
- Improves our standard channel selector.
- Adds an integration test to maintain ensure that we can interact with windows as soon as they are created

Please also regard this doc as part of this PR - https://docs.google.com/document/d/1Kn8gLqm36mKx5bjgdUjvQXMr6I92VyYwSsYm5B4d-bs/

This has been updated with code fixes, and to remove an old flow that listened for `channel-changed` rather than `window-created`, which is now unnecessary with the expect system.

Suggest leave doc comments in the doc itself