### PR TITLE
[N/A] Demo app updates - split instruments into 'name' and 'ticker'

### DIFF
--- a/res/demo/configs/non-directory/app-charts-teal-nodir.json
+++ b/res/demo/configs/non-directory/app-charts-teal-nodir.json
@@ -13,9 +13,6 @@
         "name": "fdc3",
         "manifestUrl": "http://localhost:3923/provider/app.json"
     }],
-    "shortcut": {
-        "icon": "http://localhost:3923/demo/img/app-icons/charts.svg"
-    },
     "runtime": {
         "arguments": "",
         "version": "13.76.43.31"

--- a/src/demo/apps/BlotterApp.tsx
+++ b/src/demo/apps/BlotterApp.tsx
@@ -6,24 +6,25 @@ import {ContextChannelSelector} from '../components/ContextChannelSelector/Conte
 
 export interface Symbol {
     name: string;
+    ticker: string;
 }
 
 const symbols: Symbol[] = [
-    {'name': 'AAPL'},
-    {'name': 'AMD'},
-    {'name': 'AMZN'},
-    {'name': 'CMCSA'},
-    {'name': 'CSCO'},
-    {'name': 'FB'},
-    {'name': 'GOOG'},
-    {'name': 'INTC'},
-    {'name': 'MSFT'},
-    {'name': 'NFLX'},
-    {'name': 'NVDA'},
-    {'name': 'PYPL'},
-    {'name': 'QCOM'},
-    {'name': 'ROKU'},
-    {'name': 'TSLA'}
+    {ticker: 'AAPL', name: 'Apple'},
+    {ticker: 'AMD', name: 'Advanced Micro Devices'},
+    {ticker: 'AMZN', name: 'Amazon.com'},
+    {ticker: 'CMCSA', name: 'Comcast Corporation'},
+    {ticker: 'CSCO', name: 'Cisco Systems'},
+    {ticker: 'FB', name: 'Facebook'},
+    {ticker: 'GOOG', name: 'Google'},
+    {ticker: 'INTC', name: 'Intel Corporation'},
+    {ticker: 'MSFT', name: 'Microsoft'},
+    {ticker: 'NFLX', name: 'Netflix'},
+    {ticker: 'NVDA', name: 'NVIDIA Corporation'},
+    {ticker: 'PYPL', name: 'PayPal Holdings'},
+    {ticker: 'QCOM', name: 'QUALCOMM'},
+    {ticker: 'ROKU', name: 'Roku'},
+    {ticker: 'TSLA', name: 'Tesla'}
 ];
 
 export function BlotterApp(): React.ReactElement {

--- a/src/demo/apps/ChartsApp.tsx
+++ b/src/demo/apps/ChartsApp.tsx
@@ -12,14 +12,14 @@ interface AppProps {
 }
 
 export function ChartsApp(props: AppProps): React.ReactElement {
-    const [symbolName, setSymbolName] = React.useState('Apple Inc (AAPL)');
+    const [title, setTitle] = React.useState('Apple (AAPL)');
 
     function handleIntent(context: InstrumentContext): void {
         if (context && context.name) {
             if (context.id.ticker && context.id.ticker !== context.name) {
-                setSymbolName(`${context.name} (${context.id.ticker})`);
+                setTitle(`${context.name} (${context.id.ticker})`);
             } else {
-                setSymbolName(context.name);
+                setTitle(context.name);
             }
         } else {
             throw new Error('Invalid context received');
@@ -64,7 +64,7 @@ export function ChartsApp(props: AppProps): React.ReactElement {
         <React.Fragment>
             <ContextChannelSelector float={true} />
             <div className="chart-app w3-theme">
-                <h1 className="w3-margin-left">{symbolName}</h1>
+                <h1 className="w3-margin-left">{title}</h1>
                 <Chart />
             </div>
         </React.Fragment>

--- a/src/demo/apps/ChartsApp.tsx
+++ b/src/demo/apps/ChartsApp.tsx
@@ -12,11 +12,15 @@ interface AppProps {
 }
 
 export function ChartsApp(props: AppProps): React.ReactElement {
-    const [symbolName, setSymbolName] = React.useState('AAPL');
+    const [symbolName, setSymbolName] = React.useState('Apple Inc (AAPL)');
 
     function handleIntent(context: InstrumentContext): void {
         if (context && context.name) {
-            setSymbolName(context.name);
+            if (context.id.ticker && context.id.ticker !== context.name) {
+                setSymbolName(`${context.name} (${context.id.ticker})`);
+            } else {
+                setSymbolName(context.name);
+            }
         } else {
             throw new Error('Invalid context received');
         }

--- a/src/demo/apps/NewsApp.tsx
+++ b/src/demo/apps/NewsApp.tsx
@@ -8,11 +8,15 @@ import {ContextChannelSelector} from '../components/ContextChannelSelector/Conte
 import {getCurrentChannel} from '../../client/main';
 
 export function NewsApp(): React.ReactElement {
-    const [symbolName, setSymbolName] = React.useState('AAPL');
+    const [symbolName, setSymbolName] = React.useState('Apple Inc (AAPL)');
 
     function handleIntent(context: InstrumentContext): void {
         if (context && context.name) {
-            setSymbolName(context.name);
+            if (context.id.ticker && context.id.ticker !== context.name) {
+                setSymbolName(`${context.name} (${context.id.ticker})`);
+            } else {
+                setSymbolName(context.name);
+            }
         } else {
             throw new Error('Invalid context received');
         }

--- a/src/demo/apps/NewsApp.tsx
+++ b/src/demo/apps/NewsApp.tsx
@@ -8,14 +8,14 @@ import {ContextChannelSelector} from '../components/ContextChannelSelector/Conte
 import {getCurrentChannel} from '../../client/main';
 
 export function NewsApp(): React.ReactElement {
-    const [symbolName, setSymbolName] = React.useState('Apple Inc (AAPL)');
+    const [title, setTitle] = React.useState('Apple (AAPL)');
 
     function handleIntent(context: InstrumentContext): void {
         if (context && context.name) {
             if (context.id.ticker && context.id.ticker !== context.name) {
-                setSymbolName(`${context.name} (${context.id.ticker})`);
+                setTitle(`${context.name} (${context.id.ticker})`);
             } else {
-                setSymbolName(context.name);
+                setTitle(context.name);
             }
         } else {
             throw new Error('Invalid context received');
@@ -23,8 +23,8 @@ export function NewsApp(): React.ReactElement {
     }
 
     React.useEffect(() => {
-        document.title = `News for: ${symbolName}`;
-    }, [symbolName]);
+        document.title = `News for: ${title}`;
+    }, [title]);
 
     React.useEffect(() => {
         getCurrentChannel().then(async channel => {
@@ -61,7 +61,7 @@ export function NewsApp(): React.ReactElement {
         <React.Fragment>
             <ContextChannelSelector float={true} />
             <div className="news-app">
-                <NewsFeed symbol={symbolName} />
+                <NewsFeed symbol={title} />
             </div>
         </React.Fragment>
     );

--- a/src/demo/components/blotter/SymbolsRow.tsx
+++ b/src/demo/components/blotter/SymbolsRow.tsx
@@ -83,7 +83,8 @@ export function SymbolsRow(props: SymbolsRowProps): React.ReactElement {
             type: 'fdc3.instrument',
             name: item.name,
             id: {
-                default: item.name
+                ticker: item.ticker,
+                default: item.ticker
             }
         };
     };
@@ -104,7 +105,7 @@ export function SymbolsRow(props: SymbolsRowProps): React.ReactElement {
 
     return (
         <tr className={'symbols-row' + (selected ? ' w3-theme-l2' : '')} onClick={handleClick}>
-            <td>{item.name}</td>
+            <td><span title={item.ticker}>{item.name}</span></td>
             <td>##.##</td>
             <td>##.##</td>
             <td>##.##</td>

--- a/src/demo/components/blotter/SymbolsRow.tsx
+++ b/src/demo/components/blotter/SymbolsRow.tsx
@@ -83,8 +83,7 @@ export function SymbolsRow(props: SymbolsRowProps): React.ReactElement {
             type: 'fdc3.instrument',
             name: item.name,
             id: {
-                ticker: item.ticker,
-                default: item.ticker
+                ticker: item.ticker
             }
         };
     };

--- a/src/demo/components/common/IntentButton.tsx
+++ b/src/demo/components/common/IntentButton.tsx
@@ -36,7 +36,7 @@ export function IntentButton(props: IntentButtonProps): React.ReactElement {
 
     return (
         <button onClick={handleClick} className={buttonClassName}>
-            <i className={buttonState === ButtonStateType.SPIN ? 'fa fa-spinner fa-spin' : `fa ${iconClassName}`} title={title} />
+            <i className={buttonState === ButtonStateType.SPIN ? 'fa fa-spinner fa-pulse' : `fa ${iconClassName}`} title={title} />
         </button>
     );
 }


### PR DESCRIPTION
Made instruments slightly more "realistic", removed shortcut from teal charts app.