### PR TITLE
[N/A] Fix potential memory leak

### DIFF
--- a/src/provider/model/Model.ts
+++ b/src/provider/model/Model.ts
@@ -258,6 +258,13 @@ export class Model {
         if (this._expectedWindowsById[id]) {
             return this._expectedWindowsById[id];
         } else {
+            // A promise that never resolves but rejects when the window has closed
+            const closed = allowReject(untilSignal(this._environment.windowClosed, (testIdentity) => {
+                return getId(testIdentity) === id;
+            }).then(() => {
+                throw new Error(EXPECT_CLOSED_MESSAGE);
+            }));
+
             // Create a promise that resolves once the window has been seen
             const seen = untilTrue(this._environment.windowSeen, () => {
                 return this._environment.isWindowSeen(identity);
@@ -266,33 +273,23 @@ export class Model {
             // Create a promise that resolves when the window has connected
             const connected = untilTrue(this._apiHandler.onConnection, () => {
                 return this._apiHandler.isClientConnection(identity);
-            });
+            }, closed);
 
             // Create a promise that resolves when the window has registered
-            const registered = untilTrue(this._onWindowRegisteredInternal, () => {
+            const registered = allowReject(untilTrue(this._onWindowRegisteredInternal, () => {
                 return !!this._windowsById[id];
-            }).then(() => {
+            }, closed).then(() => {
                 return this._windowsById[id];
-            });
-
-            // A promise that never resolves but rejects when the window has closed
-            const closed = allowReject(untilSignal(this._environment.windowClosed, (testIdentity) => {
-                return getId(testIdentity) === id;
-            }).then(() => {
-                throw new Error(EXPECT_CLOSED_MESSAGE);
             }));
 
-            const connectedOrClosed = allowReject(Promise.race([connected, closed]));
-            const registeredOrClosed = allowReject(Promise.race([registered, closed]));
-
             const seenThenRegisteredWithinTimeout = seen.then(() => {
-                return {value: allowReject(withStrictTimeout(Timeouts.WINDOW_SEEN_TO_REGISTERED, registeredOrClosed, EXPECT_TIMEOUT_MESSAGE))};
+                return {value: withStrictTimeout(Timeouts.WINDOW_SEEN_TO_REGISTERED, registered, EXPECT_TIMEOUT_MESSAGE)};
             });
 
             const expectedWindow: ExpectedWindow = {
                 seen: seenThenRegisteredWithinTimeout,
-                connected: connectedOrClosed,
-                registered: registeredOrClosed
+                connected,
+                registered
             };
 
             this._expectedWindowsById[id] = expectedWindow;

--- a/src/provider/model/Model.ts
+++ b/src/provider/model/Model.ts
@@ -270,12 +270,12 @@ export class Model {
                 return this._environment.isWindowSeen(identity);
             });
 
-            // Create a promise that resolves when the window has connected
+            // Create a promise that resolves when the window has connected, or rejects when the window closes
             const connected = untilTrue(this._apiHandler.onConnection, () => {
                 return this._apiHandler.isClientConnection(identity);
             }, closed);
 
-            // Create a promise that resolves when the window has registered
+            // Create a promise that resolves when the window has registered, or rejects when the window closes
             const registered = allowReject(untilTrue(this._onWindowRegisteredInternal, () => {
                 return !!this._windowsById[id];
             }, closed).then(() => {

--- a/src/provider/utils/async.ts
+++ b/src/provider/utils/async.ts
@@ -41,7 +41,8 @@ export function untilTrue<A extends any[]>(signal: Signal<A>, predicate: () => b
 }
 
 /**
-@@ -45,8 +46,9 @@ export function untilTrue<A extends any[]>(signal: Signal<A>, predicate: () => b
+ * Returns a promise that resolves when the given signal is fired, and the given predicate evaluates to true when passed the arguments
+ * recevied from the signal
  *
  * @param signal The signal to listen to
  * @param predicate The predicate to evaluate against arguments received from the signal

--- a/src/provider/utils/async.ts
+++ b/src/provider/utils/async.ts
@@ -30,7 +30,7 @@ export function withStrictTimeout<T>(timeoutMs: number, promise: Promise<T>, rej
  *
  * @param signal When this signal is fired, the predicate is revaluated
  * @param predicate The predicate to evaluate
- * @param guard A promise. If this rejects, give up listening and reject
+ * @param guard A promise. If this rejects, give up listening to the signal and reject
  */
 export function untilTrue<A extends any[]>(signal: Signal<A>, predicate: () => boolean, guard?: Promise<void>): Promise<void> {
     if (predicate()) {
@@ -45,7 +45,7 @@ export function untilTrue<A extends any[]>(signal: Signal<A>, predicate: () => b
  *
  * @param signal The signal to listen to
  * @param predicate The predicate to evaluate against arguments received from the signal
- * @param guard A promise. If this rejects, give up listening and reject
+ * @param guard A promise. If this rejects, give up listening to the signal and reject
  */
 export function untilSignal<A extends any[]>(signal: Signal<A>, predicate: (...args: A) => boolean, guard?: Promise<void>): Promise<void> {
     const promise = new DeferredPromise();

--- a/src/provider/utils/async.ts
+++ b/src/provider/utils/async.ts
@@ -22,7 +22,7 @@ export function withTimeout<T>(timeoutMs: number, promise: Promise<T>): Promise<
  */
 export function withStrictTimeout<T>(timeoutMs: number, promise: Promise<T>, rejectMessage: string): Promise<T> {
     const timeout = new Promise<T>((res, rej) => setTimeout(() => rej(new Error(rejectMessage)), timeoutMs));
-    return Promise.race([timeout, promise]);
+    return allowReject(Promise.race([timeout, promise]));
 }
 
 /**
@@ -30,23 +30,24 @@ export function withStrictTimeout<T>(timeoutMs: number, promise: Promise<T>, rej
  *
  * @param signal When this signal is fired, the predicate is revaluated
  * @param predicate The predicate to evaluate
+ * @param guard A promise. If this rejects, give up listening and reject
  */
-export function untilTrue<A extends any[]>(signal: Signal<A>, predicate: () => boolean): Promise<void> {
+export function untilTrue<A extends any[]>(signal: Signal<A>, predicate: () => boolean, guard?: Promise<void>): Promise<void> {
     if (predicate()) {
         return Promise.resolve();
     }
 
-    return untilSignal(signal, predicate);
+    return untilSignal(signal, predicate, guard);
 }
 
 /**
- * Returns a promise that resolves when the given signal is fired, and the given predicate evaluates to true when passed the arguments
- * recevied from the signal
+@@ -45,8 +46,9 @@ export function untilTrue<A extends any[]>(signal: Signal<A>, predicate: () => b
  *
  * @param signal The signal to listen to
  * @param predicate The predicate to evaluate against arguments received from the signal
+ * @param guard A promise. If this rejects, give up listening and reject
  */
-export function untilSignal<A extends any[]>(signal: Signal<A>, predicate: (...args: A) => boolean): Promise<void> {
+export function untilSignal<A extends any[]>(signal: Signal<A>, predicate: (...args: A) => boolean, guard?: Promise<void>): Promise<void> {
     const promise = new DeferredPromise();
     const slot = signal.add((...args: A) => {
         if (predicate(...args)) {
@@ -55,7 +56,14 @@ export function untilSignal<A extends any[]>(signal: Signal<A>, predicate: (...a
         }
     });
 
-    return promise.promise;
+    if (guard) {
+        guard.catch((e) => {
+            slot.remove();
+            promise.reject(e);
+        });
+    }
+
+    return allowReject(promise.promise);
 }
 
 /**


### PR DESCRIPTION
Fixes issue discovered while working on SERVICE-552

There are circumstances where listeners can be added to `Model`'s signals, but never removed (eg., a window that opens and closes, but never connects to the service). This fixes that issue