### PR TITLE
[N/A] Move getId out of Model.ts to a util file

### DIFF
--- a/src/demo/components/ContextChannelSelector/ContextChannelSelector.tsx
+++ b/src/demo/components/ContextChannelSelector/ContextChannelSelector.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {Channel, defaultChannel, getCurrentChannel, getSystemChannels, ChannelChangedEvent} from '../../../client/contextChannels';
 import {addEventListener, removeEventListener} from '../../../client/main';
-import {getId} from '../../../provider/model/Model';
+import {getId} from '../../../provider/utils/getId';
 
 import {ContextChannelView} from './ChannelMemberView';
 

--- a/src/provider/controller/ContextHandler.ts
+++ b/src/provider/controller/ContextHandler.ts
@@ -6,7 +6,7 @@ import {Context} from '../../client/main';
 import {APIHandler} from '../APIHandler';
 import {APIFromClientTopic, APIToClientTopic, ChannelReceiveContextPayload, ReceiveContextPayload} from '../../client/internal';
 import {Inject} from '../common/Injectables';
-import {getId} from '../model/Model';
+import {getId} from '../utils/getId';
 import {ContextChannel} from '../model/ContextChannel';
 
 import {ChannelHandler} from './ChannelHandler';

--- a/src/provider/model/FinEnvironment.ts
+++ b/src/provider/model/FinEnvironment.ts
@@ -12,11 +12,11 @@ import {parseIdentity} from '../../client/validation';
 import {DeferredPromise} from '../common/DeferredPromise';
 import {Events, ChannelEvents} from '../../client/internal';
 import {Injector} from '../common/Injector';
+import {getId} from '../utils/getId';
 
 import {Environment, EntityType} from './Environment';
 import {AppWindow} from './AppWindow';
 import {ContextChannel} from './ContextChannel';
-import {getId} from './Model';
 
 interface SeenWindow {
     creationTime: number | undefined;

--- a/src/provider/model/Model.ts
+++ b/src/provider/model/Model.ts
@@ -80,7 +80,7 @@ export class Model {
         return Object.values(this._channelsById);
     }
 
-    public getWindow(identity: Identity): AppWindow | null {
+    public getWindow(identity: Identity): AppWindow|null {
         return this._windowsById[getId(identity)] || null;
     }
 
@@ -102,7 +102,7 @@ export class Model {
         }
     }
 
-    public getChannel(id: ChannelId): ContextChannel | null {
+    public getChannel(id: ChannelId): ContextChannel|null {
         return this._channelsById[id] || null;
     }
 

--- a/src/provider/model/Model.ts
+++ b/src/provider/model/Model.ts
@@ -10,6 +10,7 @@ import {APIFromClientTopic} from '../../client/internal';
 import {SYSTEM_CHANNELS, Timeouts} from '../constants';
 import {withStrictTimeout, untilTrue, allowReject, untilSignal} from '../utils/async';
 import {Boxed} from '../utils/types';
+import {getId} from '../utils/getId';
 
 import {AppWindow} from './AppWindow';
 import {ContextChannel, DefaultContextChannel, SystemContextChannel} from './ContextChannel';
@@ -29,14 +30,6 @@ interface ExpectedWindow {
 
 const EXPECT_TIMEOUT_MESSAGE = 'Timeout on window registration exceeded';
 const EXPECT_CLOSED_MESSAGE = 'Window closed before registration completed';
-
-/**
- * Generates a unique `string` id for a window based on its application's uuid and window name
- * @param identity
- */
-export function getId(identity: Identity): string {
-    return `${identity.uuid}/${identity.name || identity.uuid}`;
-}
 
 @injectable()
 export class Model {
@@ -87,7 +80,7 @@ export class Model {
         return Object.values(this._channelsById);
     }
 
-    public getWindow(identity: Identity): AppWindow|null {
+    public getWindow(identity: Identity): AppWindow | null {
         return this._windowsById[getId(identity)] || null;
     }
 
@@ -109,7 +102,7 @@ export class Model {
         }
     }
 
-    public getChannel(id: ChannelId): ContextChannel|null {
+    public getChannel(id: ChannelId): ContextChannel | null {
         return this._channelsById[id] || null;
     }
 

--- a/src/provider/utils/getId.ts
+++ b/src/provider/utils/getId.ts
@@ -1,0 +1,9 @@
+import {Identity} from 'openfin/_v2/main';
+
+/**
+ * Generates a unique `string` id for a window based on its application's uuid and window name
+ * @param identity
+ */
+export function getId(identity: Identity): string {
+    return `${identity.uuid}/${identity.name || identity.uuid}`;
+}

--- a/test/demo/expect.inttest.ts
+++ b/test/demo/expect.inttest.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 import {WindowEvent} from 'openfin/_v2/api/events/base';
 
 import {DeferredPromise} from '../../src/provider/common/DeferredPromise';
-import {getId} from '../../src/provider/model/Model';
+import {getId} from '../../src/provider/utils/getId';
 
 import {testAppNotInDirectory1, appStartupTime, testManagerIdentity} from './constants';
 import {setupTeardown} from './utils/common';


### PR DESCRIPTION
Small patch to fix demo apps not working due to a change in #144 
Previously getId was being imported by the demo apps causing them to import the whole injector. 