### PR TITLE
[SERVICE-555] Ensure provider API calls to client are robust against a misbehaving client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -856,9 +856,9 @@
       "dev": true
     },
     "@types/puppeteer": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-1.20.2.tgz",
-      "integrity": "sha512-oSFCtftHSfVx8K9XPdNNYs79Zt4pYJs/0NP78ltuGCB25zS3UNGJSiypBfbhbvRC5Dcsh0k1R5Z0i8HHtqQUPQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-1.19.1.tgz",
+      "integrity": "sha512-ReWZvoEfMiJIA3AG+eM+nCx5GKrU2ANVYY5TC0nbpeiTCtnJbcqnmBbR8TkXMBTvLBYcuTOAELbTcuX73siDNQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1272,15 +1272,6 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
-    },
-    "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "dev": true,
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
     },
     "ajv": {
       "version": "6.10.2",
@@ -4275,8 +4266,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4297,14 +4287,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4319,20 +4307,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4449,8 +4434,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4462,7 +4446,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4477,7 +4460,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4485,14 +4467,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4511,7 +4491,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4592,8 +4571,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4605,7 +4583,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4691,8 +4668,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4728,7 +4704,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4748,7 +4723,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4792,14 +4766,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5255,6 +5227,15 @@
         "debug": "^3.1.0"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/mkdirp": "^0.5.2",
     "@types/node-fetch": "^2.1.6",
     "@types/openfin": "^43.0.1",
-    "@types/puppeteer": "^1.19.1",
+    "@types/puppeteer": "~1.19.1",
     "@types/react": "^16.8.6",
     "@types/react-dom": "^16.8.2",
     "hadouken-js-adapter": "^1.44.1",

--- a/src/client/contextChannels.ts
+++ b/src/client/contextChannels.ts
@@ -571,7 +571,11 @@ if (typeof fin !== 'undefined') {
         channelClient.register(APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, (payload: ChannelReceiveContextPayload) => {
             channelContextListeners.forEach((listener: ChannelContextListener) => {
                 if (listener.channel.id === payload.channel) {
-                    listener.handler(payload.context);
+                    try {
+                        listener.handler(payload.context);
+                    } catch (e) {
+                        console.warn(`Error thrown by channel context handler, swallowing error. Error message: ${e.message}`);
+                    }
                 }
             });
         });

--- a/src/client/contextChannels.ts
+++ b/src/client/contextChannels.ts
@@ -569,11 +569,11 @@ function deserializeWindowRemovedEvent(eventTransport: Transport<ChannelWindowRe
 if (typeof fin !== 'undefined') {
     getServicePromise().then((channelClient) => {
         channelClient.register(APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, (payload: ChannelReceiveContextPayload) => {
+            let successes = 0;
+            let failures = 0;
+
             channelContextListeners.forEach((listener: ChannelContextListener) => {
                 if (listener.channel.id === payload.channel) {
-                    let successes = 0;
-                    let failures = 0;
-
                     try {
                         listener.handler(payload.context);
                         successes++;
@@ -581,12 +581,12 @@ if (typeof fin !== 'undefined') {
                         failures++;
                         console.warn(`Error thrown by channel context handler, swallowing error. Error message: ${e.message}`);
                     }
-
-                    if (failures > 0 && successes === 0) {
-                        throw new Error('All channel context handlers failed');
-                    }
                 }
             });
+
+            if (failures > 0 && successes === 0) {
+                throw new Error('All channel context handlers failed');
+            }
         });
 
         const eventHandler = getEventRouter();

--- a/src/client/contextChannels.ts
+++ b/src/client/contextChannels.ts
@@ -571,10 +571,19 @@ if (typeof fin !== 'undefined') {
         channelClient.register(APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, (payload: ChannelReceiveContextPayload) => {
             channelContextListeners.forEach((listener: ChannelContextListener) => {
                 if (listener.channel.id === payload.channel) {
+                    let successes = 0;
+                    let failures = 0;
+
                     try {
                         listener.handler(payload.context);
+                        successes++;
                     } catch (e) {
+                        failures++;
                         console.warn(`Error thrown by channel context handler, swallowing error. Error message: ${e.message}`);
+                    }
+
+                    if (failures > 0 && successes === 0) {
+                        throw new Error('All channel context handlers failed');
                     }
                 }
             });

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -3,7 +3,8 @@
  */
 
 /**
- * Error codes specific to the [[open]] function.
+ * Error codes specific to the [[open]] function. Note that this is not an exhaustive list of error codes that can be returned by [[open]],
+ * which may return any of the generic error codes, such as ApplicationError.
  */
 export enum OpenError {
     /**
@@ -31,7 +32,8 @@ export enum OpenError {
 }
 
 /**
- * Error codes specific to the [[raiseIntent]] function.
+ * Error codes specific to the [[raiseIntent]] function. Note that this is not an exhaustive list of error codes that can be returned by
+ * [[raiseIntent]], which may return any of the generic error codes, such as ApplicationError.
  */
 export enum RaiseIntentError {
     /**

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -22,6 +22,10 @@ export enum OpenError {
      * Currently unused.
      */
     ResolverUnavailable = 'ResolverUnavailable',
+
+    SendContextError = 'SendContextError',
+    SendContextTimeout = 'SendContextTimeout',
+    SendContextNoHandler = 'SendContextNoHandler'
 }
 
 /**
@@ -57,7 +61,7 @@ export enum ResolveError {
     /**
      * The intent resolver UI was dismissed by the user, so the intent has been cancelled.
      */
-    ResolverClosedOrCancelled = 'ResolverClosedOrCancelled',
+    ResolverClosedOrCancelled = 'ResolverClosedOrCancelled'
 }
 
 /**

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -61,7 +61,11 @@ export enum ResolveError {
     /**
      * The intent resolver UI was dismissed by the user, so the intent has been cancelled.
      */
-    ResolverClosedOrCancelled = 'ResolverClosedOrCancelled'
+    ResolverClosedOrCancelled = 'ResolverClosedOrCancelled',
+
+    SendIntentError = 'SendIntentError',
+    SendIntentTimeout = 'SendIntentTimeout',
+    SendIntentNoHandler = 'SendContextNoHandler'
 }
 
 /**
@@ -72,6 +76,11 @@ export enum ChannelError {
      * Indicates that [[getChannelById]] has failed because no such channel exists with the given ID.
      */
     ChannelDoesNotExist = 'ChannelDoesNotExist'
+}
+
+export enum JoinError {
+    SendContextError = 'SendContextError',
+    SendContextTimeout = 'SendContextTimeout',
 }
 
 /**

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -3,65 +3,72 @@
  */
 
 /**
- * Error codes returned by actions involving creating applications.
+ * Error codes specific to the [[open]] function
  */
 export enum OpenError {
     /**
-     * Indicates that an application cannot be found in the application directory.
+     * Indicates that the an application of the provided name cannot be found in the application directory.
      */
     AppNotFound = 'AppNotFound',
 
     /**
-     * Currently unused.
+     * In the case where the optional `context` argument is provided, indicates that the provided application was started, but threw an
+     * error when attempting to handle the provided context.
      */
-    ResolverUnavailable = 'ResolverUnavailable',
-
     SendContextError = 'SendContextError',
+
+    /**
+     * In the case where the optional `context` argument is provided, indicates that the given application was started, but a timeout was
+     * reached waiting for it to handle the provided context.
+     */
     SendContextTimeout = 'SendContextTimeout',
+
+    /**
+     * In the case where the optional `context` argument is provided, indicates that the given application was started, but did not add a
+     * context handler.
+     */
     SendContextNoHandler = 'SendContextNoHandler'
 }
 
 /**
- * Error codes returned after failure to fire intents to applications.
+ * Error codes specific to the [[raiseIntent]] function
  */
-export enum ResolveError {
+export enum RaiseIntentError {
     /**
-     * Indicates that no apps could be found for a particular intent.
+     * Indicates that no apps could be found to handle the provided intent and context.
      */
     NoAppsFound = 'NoAppsFound',
     /**
-     * Indicates that, in the case when a 'target' argument is passed to [[raiseIntent]], no
-     * such app either exists in the application directory or is currently running.
+     * In the case when a the optional 'target' argument is provided, no such app either exists in the application directory or is
+     * currently running.
      */
     TargetAppNotAvailable = 'TargetAppNotAvailable',
     /**
-     * Indicates that, in the case when a 'target' argument is passed to [[raiseIntent]], the app is not able to handle this intent.
+     * In the case when a the optional 'target' argument is provided, indicates that the app is not able to handle this intent and context.
      */
     TargetAppDoesNotHandleIntent = 'TargetAppDoesNotHandleIntent',
-    /**
-     * Indicates that the provider has started an app to receive an intent, and that it has timed out whilst waiting
-     * for that app to handle the intent.
-     */
-    IntentTimeout = 'IntentTimeout',
-    /**
-     * Currently unused.
-     */
-    ResolverUnavailable = 'ResolverUnavailable',
-    /**
-     * Currently unused.
-     */
-    ResolverTimeout = 'ResolverTimeout',
     /**
      * The intent resolver UI was dismissed by the user, so the intent has been cancelled.
      */
     ResolverClosedOrCancelled = 'ResolverClosedOrCancelled',
-
+    /**
+     * Indicates that an application was started, but threw an error when attempting to handle the provided intent and context.
+     */
     SendIntentError = 'SendIntentError',
+    /**
+     * Indicates that an application was started, but a timeout was reached waiting for it to handle the provided intent and context.
+     */
     SendIntentTimeout = 'SendIntentTimeout',
+    /**
+     * Indicates that an application was started, but did not add a handler for the provided intent.
+     */
     SendIntentNoHandler = 'SendContextNoHandler'
 }
 
-export enum LaunchError {
+/**
+ * Error codes relating to launching applications
+ */
+export enum ApplicationError {
     /**
      * Indicates that an application cannot be started from an OpenFin manifest.
      */
@@ -73,21 +80,21 @@ export enum LaunchError {
 }
 
 /**
- * Error codes returned by the context channel system.
+ * Error codes relating to the context channel system
  */
 export enum ChannelError {
     /**
-     * Indicates that [[getChannelById]] has failed because no such channel exists with the given ID.
+     * Indicates that a channel of a provided ID does not exist.
      */
-    ChannelDoesNotExist = 'ChannelDoesNotExist'
+    ChannelWithIdDoesNotExist = 'ChannelDoesNotExist'
 }
 
 /**
- * Error codes returned when attempting to find specific OpenFin windows.
+ * Error codes relating to OpenFin windows.
  */
 export enum IdentityError {
     /**
-     * Indicates that a window with a particular OpenFin Identity cannot be found.
+     * Indicates that a window with a provided OpenFin Identity cannot be found.
      */
     WindowWithIdentityNotFound = 'WindowWithIdentityNotFound'
 }

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -39,12 +39,12 @@ export enum RaiseIntentError {
      */
     NoAppsFound = 'NoAppsFound',
     /**
-     * In the case when a the optional 'target' argument is provided, no such application either exists in the application directory or is
+     * In the case where the optional 'target' argument is provided, no such application either exists in the application directory or is
      * currently running.
      */
     TargetAppNotAvailable = 'TargetAppNotAvailable',
     /**
-     * In the case when a the optional 'target' argument is provided, indicates that the app is not able to handle this intent and context.
+     * In the case where the optional 'target' argument is provided, indicates that the app is not able to handle this intent and context.
      */
     TargetAppDoesNotHandleIntent = 'TargetAppDoesNotHandleIntent',
     /**

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -10,14 +10,7 @@ export enum OpenError {
      * Indicates that an application cannot be found in the application directory.
      */
     AppNotFound = 'AppNotFound',
-    /**
-     * Indicates that an application cannot be started from an OpenFin manifest.
-     */
-    ErrorOnLaunch = 'ErrorOnLaunch',
-    /**
-     * Indicates that an application was not created in a timely manner, and the provider timed out.
-     */
-    AppTimeout = 'AppTimeout',
+
     /**
      * Currently unused.
      */
@@ -66,6 +59,17 @@ export enum ResolveError {
     SendIntentError = 'SendIntentError',
     SendIntentTimeout = 'SendIntentTimeout',
     SendIntentNoHandler = 'SendContextNoHandler'
+}
+
+export enum LaunchError {
+    /**
+     * Indicates that an application cannot be started from an OpenFin manifest.
+     */
+    ErrorOnLaunch = 'ErrorOnLaunch',
+    /**
+     * Indicates that an application was not created in a timely manner, and the provider timed out.
+     */
+    AppTimeout = 'AppTimeout',
 }
 
 /**

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -7,7 +7,7 @@
  */
 export enum OpenError {
     /**
-     * Indicates that the an application of the provided name cannot be found in the application directory.
+     * Indicates that an application of the provided name cannot be found in the application directory.
      */
     AppNotFound = 'AppNotFound',
 
@@ -18,14 +18,14 @@ export enum OpenError {
     SendContextError = 'SendContextError',
 
     /**
-     * In the case where the optional `context` argument is provided, indicates that the given application was started, but a timeout was
-     * reached waiting for it to handle the provided context.
+     * In the case where the optional `context` argument is provided, indicates that the provided application was started, but a timeout
+     * was reached waiting for it to handle the provided context.
      */
     SendContextTimeout = 'SendContextTimeout',
 
     /**
-     * In the case where the optional `context` argument is provided, indicates that the given application was started, but did not add a
-     * context handler.
+     * In the case where the optional `context` argument is provided, indicates that the provided application was started, but did not add
+     * a context handler.
      */
     SendContextNoHandler = 'SendContextNoHandler'
 }
@@ -35,11 +35,11 @@ export enum OpenError {
  */
 export enum RaiseIntentError {
     /**
-     * Indicates that no apps could be found to handle the provided intent and context.
+     * Indicates that no application could be found to handle the provided intent and context.
      */
     NoAppsFound = 'NoAppsFound',
     /**
-     * In the case when a the optional 'target' argument is provided, no such app either exists in the application directory or is
+     * In the case when a the optional 'target' argument is provided, no such application either exists in the application directory or is
      * currently running.
      */
     TargetAppNotAvailable = 'TargetAppNotAvailable',
@@ -70,11 +70,11 @@ export enum RaiseIntentError {
  */
 export enum ApplicationError {
     /**
-     * Indicates that an application cannot be started from an OpenFin manifest.
+     * Indicates that an application could not be started from an OpenFin manifest.
      */
     ErrorOnLaunch = 'ErrorOnLaunch',
     /**
-     * Indicates that an application was not created in a timely manner, and the provider timed out.
+     * Indicates that a timeout was reached before the application was started.
      */
     AppTimeout = 'AppTimeout'
 }

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -76,7 +76,7 @@ export enum ApplicationError {
     /**
      * Indicates that an application was not created in a timely manner, and the provider timed out.
      */
-    AppTimeout = 'AppTimeout',
+    AppTimeout = 'AppTimeout'
 }
 
 /**

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -3,7 +3,7 @@
  */
 
 /**
- * Error codes specific to the [[open]] function
+ * Error codes specific to the [[open]] function.
  */
 export enum OpenError {
     /**
@@ -31,7 +31,7 @@ export enum OpenError {
 }
 
 /**
- * Error codes specific to the [[raiseIntent]] function
+ * Error codes specific to the [[raiseIntent]] function.
  */
 export enum RaiseIntentError {
     /**
@@ -62,11 +62,11 @@ export enum RaiseIntentError {
     /**
      * Indicates that an application was started, but did not add a handler for the provided intent.
      */
-    SendIntentNoHandler = 'SendContextNoHandler'
+    SendIntentNoHandler = 'SendIntentNoHandler'
 }
 
 /**
- * Error codes relating to launching applications
+ * Error codes relating to launching applications.
  */
 export enum ApplicationError {
     /**
@@ -80,13 +80,13 @@ export enum ApplicationError {
 }
 
 /**
- * Error codes relating to the context channel system
+ * Error codes relating to the context channel system.
  */
 export enum ChannelError {
     /**
      * Indicates that a channel of a provided ID does not exist.
      */
-    ChannelWithIdDoesNotExist = 'ChannelDoesNotExist'
+    ChannelWithIdDoesNotExist = 'ChannelWithIdDoesNotExist'
 }
 
 /**

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -78,11 +78,6 @@ export enum ChannelError {
     ChannelDoesNotExist = 'ChannelDoesNotExist'
 }
 
-export enum JoinError {
-    SendContextError = 'SendContextError',
-    SendContextTimeout = 'SendContextTimeout',
-}
-
 /**
  * Error codes returned when attempting to find specific OpenFin windows.
  */

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -257,7 +257,7 @@ export async function invokeListeners(
     listeners: Listener[],
     context: Context,
     singleFailureHandler: (e: any) => void,
-    createAllFailuresError: () => any
+    createAllFailuresError: () => Error
 ): Promise<void> {
     let successes = 0;
     let failures = 0;

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -249,7 +249,7 @@ export interface ChannelReceiveContextPayload {
  *
  * @param listeners An array of listeners to invoke
  * @param context The context to invoke the listeners with
- * @param singleFailureHandler A function that will be called when a single listener has thrown an exception
+ * @param singleFailureHandler A function that will be called each time a listener throws an exception
  * @param createAllFailuresError A function that will be called if all (and more than one) listeners fail. Should return an error, which
  * `invokeListeners` will then throw
  */

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -440,10 +440,10 @@ if (typeof fin !== 'undefined') {
         });
 
         channelClient.register(APIToClientTopic.RECEIVE_CONTEXT, (payload: ReceiveContextPayload) => {
-            contextListeners.forEach((listener: ContextListener) => {
-                let successes = 0;
-                let failures = 0;
+            let successes = 0;
+            let failures = 0;
 
+            contextListeners.forEach((listener: ContextListener) => {
                 try {
                     listener.handler(payload.context);
                     successes++;
@@ -451,11 +451,11 @@ if (typeof fin !== 'undefined') {
                     failures++;
                     console.warn(`Error thrown by context handler, swallowing error. Error message: ${e.message}`);
                 }
-
-                if (failures > 0 && successes === 0) {
-                    throw new Error('All context handlers failed');
-                }
             });
+
+            if (failures > 0 && successes === 0) {
+                throw new Error('All context handlers failed');
+            }
         });
 
         const eventHandler = getEventRouter();

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -441,10 +441,19 @@ if (typeof fin !== 'undefined') {
 
         channelClient.register(APIToClientTopic.RECEIVE_CONTEXT, (payload: ReceiveContextPayload) => {
             contextListeners.forEach((listener: ContextListener) => {
+                let successes = 0;
+                let failures = 0;
+
                 try {
                     listener.handler(payload.context);
+                    successes++;
                 } catch (e) {
+                    failures++;
                     console.warn(`Error thrown by context handler, swallowing error. Error message: ${e.message}`);
+                }
+
+                if (failures > 0 && successes === 0) {
+                    throw new Error('All context handlers failed');
                 }
             });
         });

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -461,7 +461,12 @@ if (typeof fin !== 'undefined') {
         const eventHandler = getEventRouter();
 
         channelClient.register('event', (eventTransport: Targeted<Transport<Events>>) => {
-            eventHandler.dispatchEvent(eventTransport);
+            try {
+                eventHandler.dispatchEvent(eventTransport);
+            } catch (e) {
+                console.warn(`Error thrown dispatching event, rethrowing error. Error message: ${e.message}`);
+                throw e;
+            }
         });
 
         eventHandler.registerEmitterProvider('main', () => eventEmitter);

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -423,14 +423,23 @@ if (typeof fin !== 'undefined') {
         channelClient.register(APIToClientTopic.RECEIVE_INTENT, (payload: RaiseIntentPayload) => {
             intentListeners.forEach((listener: IntentListener) => {
                 if (payload.intent === listener.intent) {
-                    listener.handler(payload.context);
+                    try {
+                        listener.handler(payload.context);
+                    } catch (e) {
+                        // / TODO: Really?!
+                        console.warn('');
+                    }
                 }
             });
         });
 
         channelClient.register(APIToClientTopic.RECEIVE_CONTEXT, (payload: ReceiveContextPayload) => {
             contextListeners.forEach((listener: ContextListener) => {
-                listener.handler(payload.context);
+                try {
+                    listener.handler(payload.context);
+                } catch (e) {
+                    console.warn(`Error thrown by context handler, swallowing error. Error message: ${e.message}`);
+                }
             });
         });
 

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -464,7 +464,7 @@ if (typeof fin !== 'undefined') {
             try {
                 eventHandler.dispatchEvent(eventTransport);
             } catch (e) {
-                console.warn(`Error thrown dispatching event, rethrowing error. Error message: ${e.message}`);
+                console.warn(`Error thrown dispatching ${eventTransport.type} event, rethrowing error. Error message: ${e.message}`);
                 throw e;
             }
         });

--- a/src/provider/constants.ts
+++ b/src/provider/constants.ts
@@ -20,7 +20,12 @@ export const Timeouts = {
     /**
      * Time service allows for a window to go from first created to being fully registered with the model
      */
-    WINDOW_CREATED_TO_REGISTERED: 5000
+    WINDOW_CREATED_TO_REGISTERED: 5000,
+
+    /**
+     * Time service allows for an API call to a client to resolve
+     */
+    SERVICE_TO_CLIENT_API_CALL: 5000
 };
 
 export const CustomConfigFields = {

--- a/src/provider/constants.ts
+++ b/src/provider/constants.ts
@@ -1,29 +1,29 @@
 /**
- * Timeouts, in milliseconds, for the different FDC3 actions
+ * Timeouts, in milliseconds, for the different FDC3 actions.
  */
 export const Timeouts = {
     /**
-     * Time before we consider an app 'mature', i.e., has had chance to register any listeners
+     * Time before we consider an app 'mature', i.e., has had chance to register any listeners.
      */
     APP_MATURITY: 5000,
 
     /**
-     * Time for an OpenFin app to start by calling `fin.Application.startFromManifest`
+     * Time for an OpenFin app to start by calling `fin.Application.startFromManifest`.
      */
     APP_START_FROM_MANIFEST: 30000,
 
     /**
-     * Time service allows for a `window-created` event after a client expects the window to exist
+     * Time service allows for a `window-created` event after a client expects the window to exist.
      */
     WINDOW_EXPECT_TO_CREATED: 250,
 
     /**
-     * Time service allows for a window to go from first created to being fully registered with the model
+     * Time service allows for a window to go from first created to being fully registered with the model.
      */
     WINDOW_CREATED_TO_REGISTERED: 5000,
 
     /**
-     * Time service allows for an API call to a client to resolve
+     * Time service allows for an API call to a client to resolve.
      */
     SERVICE_TO_CLIENT_API_CALL: 5000
 };

--- a/src/provider/controller/ChannelHandler.ts
+++ b/src/provider/controller/ChannelHandler.ts
@@ -106,7 +106,7 @@ export class ChannelHandler {
         const channel = this._model.getChannel(channelId);
 
         if (!channel) {
-            throw new FDC3Error(ChannelError.ChannelDoesNotExist, `No channel with channelId: ${channelId}`);
+            throw new FDC3Error(ChannelError.ChannelWithIdDoesNotExist, `No channel with channelId: ${channelId}`);
         }
     }
 

--- a/src/provider/controller/ContextHandler.ts
+++ b/src/provider/controller/ContextHandler.ts
@@ -44,9 +44,9 @@ export class ContextHandler {
             // We intentionally don't await this, as we have no expectation that windows will add a context listener
             window.waitForReadyToReceiveContext().then(() => {
                 collateApiCallResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_CONTEXT, payload)]).then(([result]) => {
-                    if (result === CollateApiCallResultsResult.AllFailure) {
+                    if (result === CollateApiCallResultsResult.ALL_FAILURE) {
                         console.warn(`Error thrown by client window ${window.id} attempting to handle context, swallowing error`);
-                    } else if (result === CollateApiCallResultsResult.Timeout) {
+                    } else if (result === CollateApiCallResultsResult.TIMEOUT) {
                         console.warn(`Timeout waiting for client window ${window.id} to handle context, swallowing error`);
                     }
                 });
@@ -124,9 +124,9 @@ export class ContextHandler {
 
     private async sendForBroadcast(window: AppWindow, context: Context): Promise<void> {
         await collateApiCallResults([this.send(window, context)]).then(([result]) => {
-            if (result === CollateApiCallResultsResult.AllFailure) {
+            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
                 console.warn(`Error thrown by client window ${window.id} attempting to handle broadcast, swallowing error`);
-            } else if (result === CollateApiCallResultsResult.Timeout) {
+            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client window ${window.id} to handle broadcast, swallowing error`);
             }
         });
@@ -143,9 +143,9 @@ export class ContextHandler {
         const payload: ChannelReceiveContextPayload = {channel: channel.id, context};
 
         await collateApiCallResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, payload)]).then(([result]) => {
-            if (result === CollateApiCallResultsResult.AllFailure) {
+            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
                 console.warn(`Error thrown by client window ${window.id} attempting to handle broadcast on channel, swallowing error`);
-            } else if (result === CollateApiCallResultsResult.Timeout) {
+            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client window ${window.id} to handle broadcast on channel, swallowing error`);
             }
         });

--- a/src/provider/controller/ContextHandler.ts
+++ b/src/provider/controller/ContextHandler.ts
@@ -9,6 +9,7 @@ import {getId} from '../utils/getId';
 import {ContextChannel} from '../model/ContextChannel';
 import {Model} from '../model/Model';
 import {LiveApp} from '../model/LiveApp';
+import {withTimeout} from '../utils/async';
 
 import {ChannelHandler} from './ChannelHandler';
 
@@ -124,6 +125,6 @@ export class ContextHandler {
     private async sendOnChannel(window: AppWindow, context: Context, channel: ContextChannel): Promise<void> {
         const payload: ChannelReceiveContextPayload = {channel: channel.id, context};
 
-        await this._apiHandler.dispatch(window.identity, APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, payload);
+        await withTimeout(5000, this._apiHandler.dispatch(window.identity, APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, payload)).catch(() => {});
     }
 }

--- a/src/provider/controller/ContextHandler.ts
+++ b/src/provider/controller/ContextHandler.ts
@@ -9,7 +9,7 @@ import {getId} from '../utils/getId';
 import {ContextChannel} from '../model/ContextChannel';
 import {Model} from '../model/Model';
 import {LiveApp} from '../model/LiveApp';
-import {collateClientCalls, CollateClientCallsResult} from '../utils/helpers';
+import {collateClientCalls, ClientCallsResult} from '../utils/helpers';
 
 import {ChannelHandler} from './ChannelHandler';
 
@@ -44,9 +44,9 @@ export class ContextHandler {
             // We intentionally don't await this, as we have no expectation that windows will add a context listener
             window.waitForReadyToReceiveContext().then(() => {
                 collateClientCalls([this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_CONTEXT, payload)]).then(([result]) => {
-                    if (result === CollateClientCallsResult.ALL_FAILURE) {
+                    if (result === ClientCallsResult.ALL_FAILURE) {
                         console.warn(`Error thrown by client window ${window.id} attempting to handle context, swallowing error`);
-                    } else if (result === CollateClientCallsResult.TIMEOUT) {
+                    } else if (result === ClientCallsResult.TIMEOUT) {
                         console.warn(`Timeout waiting for client window ${window.id} to handle context, swallowing error`);
                     }
                 });
@@ -124,9 +124,9 @@ export class ContextHandler {
 
     private async sendForBroadcast(window: AppWindow, context: Context): Promise<void> {
         await collateClientCalls([this.send(window, context)]).then(([result]) => {
-            if (result === CollateClientCallsResult.ALL_FAILURE) {
+            if (result === ClientCallsResult.ALL_FAILURE) {
                 console.warn(`Error thrown by client window ${window.id} attempting to handle broadcast, swallowing error`);
-            } else if (result === CollateClientCallsResult.TIMEOUT) {
+            } else if (result === ClientCallsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client window ${window.id} to handle broadcast, swallowing error`);
             }
         });
@@ -143,9 +143,9 @@ export class ContextHandler {
         const payload: ChannelReceiveContextPayload = {channel: channel.id, context};
 
         await collateClientCalls([this._apiHandler.dispatch(window.identity, APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, payload)]).then(([result]) => {
-            if (result === CollateClientCallsResult.ALL_FAILURE) {
+            if (result === ClientCallsResult.ALL_FAILURE) {
                 console.warn(`Error thrown by client window ${window.id} attempting to handle broadcast on channel, swallowing error`);
-            } else if (result === CollateClientCallsResult.TIMEOUT) {
+            } else if (result === ClientCallsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client window ${window.id} to handle broadcast on channel, swallowing error`);
             }
         });

--- a/src/provider/controller/ContextHandler.ts
+++ b/src/provider/controller/ContextHandler.ts
@@ -9,7 +9,7 @@ import {getId} from '../utils/getId';
 import {ContextChannel} from '../model/ContextChannel';
 import {Model} from '../model/Model';
 import {LiveApp} from '../model/LiveApp';
-import {collateApiCallResults, CollateApiCallResultsResult} from '../utils/async';
+import {collateClientCalls, CollateClientCallsResult} from '../utils/helpers';
 
 import {ChannelHandler} from './ChannelHandler';
 
@@ -43,10 +43,10 @@ export class ContextHandler {
         } else {
             // We intentionally don't await this, as we have no expectation that windows will add a context listener
             window.waitForReadyToReceiveContext().then(() => {
-                collateApiCallResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_CONTEXT, payload)]).then(([result]) => {
-                    if (result === CollateApiCallResultsResult.ALL_FAILURE) {
+                collateClientCalls([this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_CONTEXT, payload)]).then(([result]) => {
+                    if (result === CollateClientCallsResult.ALL_FAILURE) {
                         console.warn(`Error thrown by client window ${window.id} attempting to handle context, swallowing error`);
-                    } else if (result === CollateApiCallResultsResult.TIMEOUT) {
+                    } else if (result === CollateClientCallsResult.TIMEOUT) {
                         console.warn(`Timeout waiting for client window ${window.id} to handle context, swallowing error`);
                     }
                 });
@@ -123,10 +123,10 @@ export class ContextHandler {
     }
 
     private async sendForBroadcast(window: AppWindow, context: Context): Promise<void> {
-        await collateApiCallResults([this.send(window, context)]).then(([result]) => {
-            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
+        await collateClientCalls([this.send(window, context)]).then(([result]) => {
+            if (result === CollateClientCallsResult.ALL_FAILURE) {
                 console.warn(`Error thrown by client window ${window.id} attempting to handle broadcast, swallowing error`);
-            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
+            } else if (result === CollateClientCallsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client window ${window.id} to handle broadcast, swallowing error`);
             }
         });
@@ -142,10 +142,10 @@ export class ContextHandler {
     private async sendOnChannelForBroadcast(window: AppWindow, context: Context, channel: ContextChannel): Promise<void> {
         const payload: ChannelReceiveContextPayload = {channel: channel.id, context};
 
-        await collateApiCallResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, payload)]).then(([result]) => {
-            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
+        await collateClientCalls([this._apiHandler.dispatch(window.identity, APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, payload)]).then(([result]) => {
+            if (result === CollateClientCallsResult.ALL_FAILURE) {
                 console.warn(`Error thrown by client window ${window.id} attempting to handle broadcast on channel, swallowing error`);
-            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
+            } else if (result === CollateClientCallsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client window ${window.id} to handle broadcast on channel, swallowing error`);
             }
         });

--- a/src/provider/controller/ContextHandler.ts
+++ b/src/provider/controller/ContextHandler.ts
@@ -9,7 +9,7 @@ import {getId} from '../utils/getId';
 import {ContextChannel} from '../model/ContextChannel';
 import {Model} from '../model/Model';
 import {LiveApp} from '../model/LiveApp';
-import {collateResults} from '../utils/async';
+import {collateApiCallResults, CollateApiCallResultsResult} from '../utils/async';
 
 import {ChannelHandler} from './ChannelHandler';
 
@@ -41,11 +41,11 @@ export class ContextHandler {
         } else {
             // We intentionally don't await this, as we have no expectation that windows will add a context listener
             window.waitForReadyToReceiveContext().then(() => {
-                collateResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_CONTEXT, payload)]).then(([result]) => {
-                    if (result === 'error') {
-                        console.warn('Error from client sending, swallowing');
-                    } else if (result === 'timeout') {
-                        console.warn('Timeout from client sending, swallowing');
+                collateApiCallResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_CONTEXT, payload)]).then(([result]) => {
+                    if (result === CollateApiCallResultsResult.AllFailure) {
+                        console.warn('Error thrown by client attempting to handle context, swallowing error');
+                    } else if (result === CollateApiCallResultsResult.Timeout) {
+                        console.warn('Timeout waiting for client to handle context, swallowing error');
                     }
                 });
             }, () => {});
@@ -121,11 +121,11 @@ export class ContextHandler {
     }
 
     private async sendForBroadcast(window: AppWindow, context: Context): Promise<void> {
-        await collateResults([this.send(window, context)]).then(([result]) => {
-            if (result === 'error') {
-                console.warn('Error from client sending on channel, swallowing');
-            } else if (result === 'timeout') {
-                console.warn('Timeout from client sending on channel, swallowing');
+        await collateApiCallResults([this.send(window, context)]).then(([result]) => {
+            if (result === CollateApiCallResultsResult.AllFailure) {
+                console.warn('Error thrown by client attempting to handle broadcast, swallowing error');
+            } else if (result === CollateApiCallResultsResult.Timeout) {
+                console.warn('Timeout waiting for client to handle broadcast, swallowing error');
             }
         });
     }
@@ -139,11 +139,11 @@ export class ContextHandler {
     private async sendOnChannelForBroadcast(window: AppWindow, context: Context, channel: ContextChannel): Promise<void> {
         const payload: ChannelReceiveContextPayload = {channel: channel.id, context};
 
-        await collateResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, payload)]).then(([result]) => {
-            if (result === 'error') {
-                console.warn('Error from client sending on channel, swallowing');
-            } else if (result === 'timeout') {
-                console.warn('Timeout from client sending on channel, swallowing');
+        await collateApiCallResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, payload)]).then(([result]) => {
+            if (result === CollateApiCallResultsResult.AllFailure) {
+                console.warn('Error thrown by client attempting to handle broadcast on channel, swallowing error');
+            } else if (result === CollateApiCallResultsResult.Timeout) {
+                console.warn('Timeout waiting for client to handle broadcast on channel, swallowing error');
             }
         });
     }

--- a/src/provider/controller/ContextHandler.ts
+++ b/src/provider/controller/ContextHandler.ts
@@ -30,7 +30,9 @@ export class ContextHandler {
     }
 
     /**
-     * Send a context to a specific app
+     * Send a context to a specific window. The promise returned may reject if provided window throws an error, so caller should take
+     * responsibility for error handling.
+     *
      * @param window Window to send the context to
      * @param context Context to be sent
      */
@@ -43,9 +45,9 @@ export class ContextHandler {
             window.waitForReadyToReceiveContext().then(() => {
                 collateApiCallResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_CONTEXT, payload)]).then(([result]) => {
                     if (result === CollateApiCallResultsResult.AllFailure) {
-                        console.warn('Error thrown by client attempting to handle context, swallowing error');
+                        console.warn(`Error thrown by client window ${window.id} attempting to handle context, swallowing error`);
                     } else if (result === CollateApiCallResultsResult.Timeout) {
-                        console.warn('Timeout waiting for client to handle context, swallowing error');
+                        console.warn(`Timeout waiting for client window ${window.id} to handle context, swallowing error`);
                     }
                 });
             }, () => {});
@@ -56,7 +58,7 @@ export class ContextHandler {
 
     /**
      * Broadcast context onto the channel the source window is a member of. The context will be received by all
-     * windows in the channel, or listening to the channel, except for the sender itself
+     * windows in the channel, or listening to the channel, except for the sender itself.
      *
      * @param context Context to send
      * @param source Window sending the context. It won't receive the broadcast
@@ -67,7 +69,7 @@ export class ContextHandler {
 
     /**
      * Broadcast context onto the provided channel. The context will be received by all windows in the channel, or
-     * listening to the channel, except for the sender itself
+     * listening to the channel, except for the sender itself.
      *
      * @param context Context to send
      * @param source Window sending the context. It won't receive the broadcast
@@ -123,15 +125,16 @@ export class ContextHandler {
     private async sendForBroadcast(window: AppWindow, context: Context): Promise<void> {
         await collateApiCallResults([this.send(window, context)]).then(([result]) => {
             if (result === CollateApiCallResultsResult.AllFailure) {
-                console.warn('Error thrown by client attempting to handle broadcast, swallowing error');
+                console.warn(`Error thrown by client window ${window.id} attempting to handle broadcast, swallowing error`);
             } else if (result === CollateApiCallResultsResult.Timeout) {
-                console.warn('Timeout waiting for client to handle broadcast, swallowing error');
+                console.warn(`Timeout waiting for client window ${window.id} to handle broadcast, swallowing error`);
             }
         });
     }
 
     /**
-     * Send a context to a specific app on a specific channel
+     * Send a context to a specific app on a specific channel.
+     *
      * @param window Window to send the context to
      * @param context Context to be sent
      * @param channel Channel context is to be sent on
@@ -141,9 +144,9 @@ export class ContextHandler {
 
         await collateApiCallResults([this._apiHandler.dispatch(window.identity, APIToClientTopic.CHANNEL_RECEIVE_CONTEXT, payload)]).then(([result]) => {
             if (result === CollateApiCallResultsResult.AllFailure) {
-                console.warn('Error thrown by client attempting to handle broadcast on channel, swallowing error');
+                console.warn(`Error thrown by client window ${window.id} attempting to handle broadcast on channel, swallowing error`);
             } else if (result === CollateApiCallResultsResult.Timeout) {
-                console.warn('Timeout waiting for client to handle broadcast on channel, swallowing error');
+                console.warn(`Timeout waiting for client window ${window.id} to handle broadcast on channel, swallowing error`);
             }
         });
     }

--- a/src/provider/controller/EventHandler.ts
+++ b/src/provider/controller/EventHandler.ts
@@ -7,7 +7,7 @@ import {Inject} from '../common/Injectables';
 import {ContextChannel} from '../model/ContextChannel';
 import {ChannelWindowAddedEvent, ChannelWindowRemovedEvent, ChannelChangedEvent} from '../../client/main';
 import {Transport, Targeted} from '../../client/EventRouter';
-import {collateResults} from '../utils/async';
+import {collateApiCallResults, CollateApiCallResultsResult} from '../utils/async';
 
 import {ChannelHandler} from './ChannelHandler';
 
@@ -71,21 +71,21 @@ export class EventHandler {
     }
 
     private dispatchEvent<T extends Events>(targetWindow: AppWindow, eventTransport: Targeted<Transport<T>>): Promise<void> {
-        return collateResults([this._apiHandler.dispatch(targetWindow.identity, 'event', eventTransport)]).then(([result]) => {
-            if (result === 'error') {
-                console.warn('Error publishing to client');
-            } else if (result === 'timeout') {
-                console.warn('Timeout publishing to client');
+        return collateApiCallResults([this._apiHandler.dispatch(targetWindow.identity, 'event', eventTransport)]).then(([result]) => {
+            if (result === CollateApiCallResultsResult.AllFailure) {
+                console.warn(`Error thrown by client attempting to handle event ${eventTransport.type}, swallowing error`);
+            } else if (result === CollateApiCallResultsResult.Timeout) {
+                console.warn(`Timeout waiting for client to handle event ${eventTransport.type}, swallowing error`);
             }
         });
     }
 
     private publishEvent<T extends Events>(eventTransport: Targeted<Transport<T>>): Promise<void> {
-        return collateResults(this._apiHandler.publish('event', eventTransport)).then(([result]) => {
-            if (result === 'error') {
-                console.warn('Error publishing to client');
-            } else if (result === 'timeout') {
-                console.warn('Timeout publishing to client');
+        return collateApiCallResults(this._apiHandler.publish('event', eventTransport)).then(([result]) => {
+            if (result === CollateApiCallResultsResult.AllFailure) {
+                console.warn(`Error(s) thrown by client attempting to handle event ${eventTransport.type}, swallowing error(s)`);
+            } else if (result === CollateApiCallResultsResult.Timeout) {
+                console.warn(`Timeout waiting for client to handle event ${eventTransport.type}, swallowing error`);
             }
         });
     }

--- a/src/provider/controller/EventHandler.ts
+++ b/src/provider/controller/EventHandler.ts
@@ -7,7 +7,7 @@ import {Inject} from '../common/Injectables';
 import {ContextChannel} from '../model/ContextChannel';
 import {ChannelWindowAddedEvent, ChannelWindowRemovedEvent, ChannelChangedEvent} from '../../client/main';
 import {Transport, Targeted} from '../../client/EventRouter';
-import {collateApiCallResults, CollateApiCallResultsResult} from '../utils/async';
+import {collateClientCalls, CollateClientCallsResult} from '../utils/helpers';
 
 import {ChannelHandler} from './ChannelHandler';
 
@@ -71,20 +71,20 @@ export class EventHandler {
     }
 
     private dispatchEvent<T extends Events>(targetWindow: AppWindow, eventTransport: Targeted<Transport<T>>): Promise<void> {
-        return collateApiCallResults([this._apiHandler.dispatch(targetWindow.identity, 'event', eventTransport)]).then(([result]) => {
-            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
+        return collateClientCalls([this._apiHandler.dispatch(targetWindow.identity, 'event', eventTransport)]).then(([result]) => {
+            if (result === CollateClientCallsResult.ALL_FAILURE) {
                 console.warn(`Error thrown by client attempting to handle event ${eventTransport.type}, swallowing error`);
-            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
+            } else if (result === CollateClientCallsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client to handle event ${eventTransport.type}, swallowing error`);
             }
         });
     }
 
     private publishEvent<T extends Events>(eventTransport: Targeted<Transport<T>>): Promise<void> {
-        return collateApiCallResults(this._apiHandler.publish('event', eventTransport)).then(([result]) => {
-            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
+        return collateClientCalls(this._apiHandler.publish('event', eventTransport)).then(([result]) => {
+            if (result === CollateClientCallsResult.ALL_FAILURE) {
                 console.warn(`Error(s) thrown by client attempting to handle event ${eventTransport.type}, swallowing error(s)`);
-            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
+            } else if (result === CollateClientCallsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client to handle event ${eventTransport.type}, swallowing error`);
             }
         });

--- a/src/provider/controller/EventHandler.ts
+++ b/src/provider/controller/EventHandler.ts
@@ -72,9 +72,9 @@ export class EventHandler {
 
     private dispatchEvent<T extends Events>(targetWindow: AppWindow, eventTransport: Targeted<Transport<T>>): Promise<void> {
         return collateApiCallResults([this._apiHandler.dispatch(targetWindow.identity, 'event', eventTransport)]).then(([result]) => {
-            if (result === CollateApiCallResultsResult.AllFailure) {
+            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
                 console.warn(`Error thrown by client attempting to handle event ${eventTransport.type}, swallowing error`);
-            } else if (result === CollateApiCallResultsResult.Timeout) {
+            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client to handle event ${eventTransport.type}, swallowing error`);
             }
         });
@@ -82,9 +82,9 @@ export class EventHandler {
 
     private publishEvent<T extends Events>(eventTransport: Targeted<Transport<T>>): Promise<void> {
         return collateApiCallResults(this._apiHandler.publish('event', eventTransport)).then(([result]) => {
-            if (result === CollateApiCallResultsResult.AllFailure) {
+            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
                 console.warn(`Error(s) thrown by client attempting to handle event ${eventTransport.type}, swallowing error(s)`);
-            } else if (result === CollateApiCallResultsResult.Timeout) {
+            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client to handle event ${eventTransport.type}, swallowing error`);
             }
         });

--- a/src/provider/controller/EventHandler.ts
+++ b/src/provider/controller/EventHandler.ts
@@ -7,7 +7,7 @@ import {Inject} from '../common/Injectables';
 import {ContextChannel} from '../model/ContextChannel';
 import {ChannelWindowAddedEvent, ChannelWindowRemovedEvent, ChannelChangedEvent} from '../../client/main';
 import {Transport, Targeted} from '../../client/EventRouter';
-import {collateClientCalls, CollateClientCallsResult} from '../utils/helpers';
+import {collateClientCalls, ClientCallsResult} from '../utils/helpers';
 
 import {ChannelHandler} from './ChannelHandler';
 
@@ -72,9 +72,9 @@ export class EventHandler {
 
     private dispatchEvent<T extends Events>(targetWindow: AppWindow, eventTransport: Targeted<Transport<T>>): Promise<void> {
         return collateClientCalls([this._apiHandler.dispatch(targetWindow.identity, 'event', eventTransport)]).then(([result]) => {
-            if (result === CollateClientCallsResult.ALL_FAILURE) {
+            if (result === ClientCallsResult.ALL_FAILURE) {
                 console.warn(`Error thrown by client attempting to handle event ${eventTransport.type}, swallowing error`);
-            } else if (result === CollateClientCallsResult.TIMEOUT) {
+            } else if (result === ClientCallsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client to handle event ${eventTransport.type}, swallowing error`);
             }
         });
@@ -82,9 +82,9 @@ export class EventHandler {
 
     private publishEvent<T extends Events>(eventTransport: Targeted<Transport<T>>): Promise<void> {
         return collateClientCalls(this._apiHandler.publish('event', eventTransport)).then(([result]) => {
-            if (result === CollateClientCallsResult.ALL_FAILURE) {
+            if (result === ClientCallsResult.ALL_FAILURE) {
                 console.warn(`Error(s) thrown by client attempting to handle event ${eventTransport.type}, swallowing error(s)`);
-            } else if (result === CollateClientCallsResult.TIMEOUT) {
+            } else if (result === ClientCallsResult.TIMEOUT) {
                 console.warn(`Timeout waiting for client to handle event ${eventTransport.type}, swallowing error`);
             }
         });

--- a/src/provider/controller/IntentHandler.ts
+++ b/src/provider/controller/IntentHandler.ts
@@ -132,7 +132,7 @@ export class IntentHandler {
         if (listeningWindows.length > 0) {
             const payload: ReceiveIntentPayload = {context: intent.context, intent: intent.type};
 
-            const [result] = await collateResults(5000, listeningWindows.map((window) => {
+            const [result] = await collateResults(listeningWindows.map((window) => {
                 return this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_INTENT, payload);
             }));
 

--- a/src/provider/controller/IntentHandler.ts
+++ b/src/provider/controller/IntentHandler.ts
@@ -3,7 +3,7 @@ import {injectable, inject} from 'inversify';
 import {Inject} from '../common/Injectables';
 import {Intent} from '../intents';
 import {IntentResolution, Application} from '../../client/main';
-import {FDC3Error, ResolveError} from '../../client/errors';
+import {FDC3Error, RaiseIntentError} from '../../client/errors';
 import {Model} from '../model/Model';
 import {APIToClientTopic, ReceiveIntentPayload} from '../../client/internal';
 import {APIHandler} from '../APIHandler';
@@ -49,13 +49,13 @@ export class IntentHandler {
         } else if (await this._model.existsAppForName(intent.target)) {
             // Target exists but does not handle intent with given context
             throw new FDC3Error(
-                ResolveError.TargetAppDoesNotHandleIntent,
+                RaiseIntentError.TargetAppDoesNotHandleIntent,
                 `App '${intent.target}' does not handle intent '${intent.type}' with context '${intent.context.type}'`
             );
         } else {
             // Target does not exist
             throw new FDC3Error(
-                ResolveError.TargetAppNotAvailable,
+                RaiseIntentError.TargetAppNotAvailable,
                 `Couldn't resolve intent target '${intent.target}'. No matching app in directory or currently running.`
             );
         }
@@ -68,7 +68,7 @@ export class IntentHandler {
         const apps: Application[] = await this._model.getApplicationsForIntent(intent.type, intent.context.type);
 
         if (apps.length === 0) {
-            throw new FDC3Error(ResolveError.NoAppsFound, 'No applications available to handle this intent');
+            throw new FDC3Error(RaiseIntentError.NoAppsFound, 'No applications available to handle this intent');
         } else if (apps.length === 1) {
             console.log(`App '${apps[0].name}' found to resolve intent '${intent.type}, firing intent'`);
 
@@ -114,7 +114,7 @@ export class IntentHandler {
         });
 
         if (!selection) {
-            throw new FDC3Error(ResolveError.ResolverClosedOrCancelled, 'Resolver closed or cancelled');
+            throw new FDC3Error(RaiseIntentError.ResolverClosedOrCancelled, 'Resolver closed or cancelled');
         }
 
         // Handle response
@@ -137,12 +137,12 @@ export class IntentHandler {
             }));
 
             if (result === CollateApiCallResultsResult.AllFailure) {
-                throw new FDC3Error(ResolveError.SendIntentError, 'Error(s) thrown by client attempting to handle intent');
+                throw new FDC3Error(RaiseIntentError.SendIntentError, 'Error(s) thrown by client attempting to handle intent');
             } else if (result === CollateApiCallResultsResult.Timeout) {
-                throw new FDC3Error(ResolveError.SendIntentTimeout, 'Timeout waiting for client to handle intent');
+                throw new FDC3Error(RaiseIntentError.SendIntentTimeout, 'Timeout waiting for client to handle intent');
             }
         } else {
-            throw new FDC3Error(ResolveError.SendIntentNoHandler, `No intent handler added for intent: ${intent.type}`);
+            throw new FDC3Error(RaiseIntentError.SendIntentNoHandler, `No intent handler added for intent: ${intent.type}`);
         }
 
         const result: IntentResolution = {

--- a/src/provider/controller/IntentHandler.ts
+++ b/src/provider/controller/IntentHandler.ts
@@ -136,9 +136,9 @@ export class IntentHandler {
                 return this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_INTENT, payload);
             }));
 
-            if (result === CollateApiCallResultsResult.AllFailure) {
+            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
                 throw new FDC3Error(RaiseIntentError.SendIntentError, 'Error(s) thrown by client attempting to handle intent');
-            } else if (result === CollateApiCallResultsResult.Timeout) {
+            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
                 throw new FDC3Error(RaiseIntentError.SendIntentTimeout, 'Timeout waiting for client to handle intent');
             }
         } else {

--- a/src/provider/controller/IntentHandler.ts
+++ b/src/provider/controller/IntentHandler.ts
@@ -7,7 +7,7 @@ import {FDC3Error, RaiseIntentError} from '../../client/errors';
 import {Model} from '../model/Model';
 import {APIToClientTopic, ReceiveIntentPayload} from '../../client/internal';
 import {APIHandler} from '../APIHandler';
-import {collateClientCalls, CollateClientCallsResult} from '../utils/helpers';
+import {collateClientCalls, ClientCallsResult} from '../utils/helpers';
 
 import {ResolverResult, ResolverHandlerBinding} from './ResolverHandler';
 
@@ -136,9 +136,9 @@ export class IntentHandler {
                 return this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_INTENT, payload);
             }));
 
-            if (result === CollateClientCallsResult.ALL_FAILURE) {
+            if (result === ClientCallsResult.ALL_FAILURE) {
                 throw new FDC3Error(RaiseIntentError.SendIntentError, 'Error(s) thrown by client attempting to handle intent');
-            } else if (result === CollateClientCallsResult.TIMEOUT) {
+            } else if (result === ClientCallsResult.TIMEOUT) {
                 throw new FDC3Error(RaiseIntentError.SendIntentTimeout, 'Timeout waiting for client to handle intent');
             }
         } else {

--- a/src/provider/controller/IntentHandler.ts
+++ b/src/provider/controller/IntentHandler.ts
@@ -7,7 +7,7 @@ import {FDC3Error, RaiseIntentError} from '../../client/errors';
 import {Model} from '../model/Model';
 import {APIToClientTopic, ReceiveIntentPayload} from '../../client/internal';
 import {APIHandler} from '../APIHandler';
-import {collateApiCallResults, CollateApiCallResultsResult} from '../utils/async';
+import {collateClientCalls, CollateClientCallsResult} from '../utils/helpers';
 
 import {ResolverResult, ResolverHandlerBinding} from './ResolverHandler';
 
@@ -132,13 +132,13 @@ export class IntentHandler {
         if (listeningWindows.length > 0) {
             const payload: ReceiveIntentPayload = {context: intent.context, intent: intent.type};
 
-            const [result] = await collateApiCallResults(listeningWindows.map((window) => {
+            const [result] = await collateClientCalls(listeningWindows.map((window) => {
                 return this._apiHandler.dispatch(window.identity, APIToClientTopic.RECEIVE_INTENT, payload);
             }));
 
-            if (result === CollateApiCallResultsResult.ALL_FAILURE) {
+            if (result === CollateClientCallsResult.ALL_FAILURE) {
                 throw new FDC3Error(RaiseIntentError.SendIntentError, 'Error(s) thrown by client attempting to handle intent');
-            } else if (result === CollateApiCallResultsResult.TIMEOUT) {
+            } else if (result === CollateClientCallsResult.TIMEOUT) {
                 throw new FDC3Error(RaiseIntentError.SendIntentTimeout, 'Timeout waiting for client to handle intent');
             }
         } else {

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -3,7 +3,7 @@ import {inject, injectable} from 'inversify';
 import {Identity} from 'openfin/_v2/main';
 import {ProviderIdentity} from 'openfin/_v2/api/interappbus/channel/channel';
 
-import {FDC3Error, OpenError, IdentityError, JoinError} from '../client/errors';
+import {FDC3Error, OpenError, IdentityError} from '../client/errors';
 import {RaiseIntentPayload, APIFromClientTopic, OpenPayload, FindIntentPayload, FindIntentsByContextPayload, BroadcastPayload, APIFromClient, AddIntentListenerPayload, RemoveIntentListenerPayload, GetSystemChannelsPayload, GetCurrentChannelPayload, ChannelGetMembersPayload, ChannelJoinPayload, ChannelTransport, SystemChannelTransport, GetChannelByIdPayload, ChannelBroadcastPayload, ChannelGetCurrentContextPayload, ChannelAddContextListenerPayload, ChannelRemoveContextListenerPayload, ChannelAddEventListenerPayload, ChannelRemoveEventListenerPayload, GetOrCreateAppChannelPayload, AppChannelTransport, AddContextListenerPayload, RemoveContextListenerPayload} from '../client/internal';
 import {AppIntent, IntentResolution, Application, Context} from '../client/main';
 import {parseIdentity, parseContext, parseChannelId, parseAppChannelName} from '../client/validation';
@@ -277,16 +277,7 @@ export class Main {
         const context = this._channelHandler.getChannelContext(channel);
 
         if (context) {
-            let error = true;
-            const [timedout] = await withTimeout(5000, this._contextHandler.send(appWindow, context).catch(() => {
-                error = true;
-            }));
-
-            if (error) {
-                throw new FDC3Error(JoinError.SendContextError, '');
-            } else if (timedout) {
-                throw new FDC3Error(JoinError.SendContextTimeout, '');
-            }
+            await withTimeout(5000, this._contextHandler.send(appWindow, context).catch(() => {}));
         }
     }
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -22,7 +22,7 @@ import {Intent} from './intents';
 import {ConfigStoreBinding} from './model/ConfigStore';
 import {ContextChannel} from './model/ContextChannel';
 import {Environment} from './model/Environment';
-import {collateClientCalls, CollateClientCallsResult} from './utils/helpers';
+import {collateClientCalls, ClientCallsResult} from './utils/helpers';
 
 @injectable()
 export class Main {
@@ -151,9 +151,9 @@ export class Main {
 
                 const [result] = await collateClientCalls(expectedWindows.map((window) => this._contextHandler.send(window, context)));
 
-                if (result === CollateClientCallsResult.ALL_FAILURE) {
+                if (result === ClientCallsResult.ALL_FAILURE) {
                     throw new FDC3Error(OpenError.SendContextError, 'Error(s) thrown by client attempting to handle context on app starting');
-                } else if (result === CollateClientCallsResult.TIMEOUT) {
+                } else if (result === ClientCallsResult.TIMEOUT) {
                     throw new FDC3Error(OpenError.SendContextTimeout, 'Timeout waiting for client to handle context on app starting');
                 }
             });
@@ -278,9 +278,9 @@ export class Main {
 
         if (context) {
             await collateClientCalls([this._contextHandler.send(appWindow, context)]).then(([result]) => {
-                if (result === CollateClientCallsResult.ALL_FAILURE) {
+                if (result === ClientCallsResult.ALL_FAILURE) {
                     console.warn(`Error thrown by client window ${appWindow.id} attempting to handle context on joining channel, swallowing error`);
-                } else if (result === CollateClientCallsResult.TIMEOUT) {
+                } else if (result === ClientCallsResult.TIMEOUT) {
                     console.warn(`Timeout waiting for client window ${appWindow.id} to handle context on joining channel, swallowing error`);
                 }
             });

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -106,7 +106,7 @@ export class Main {
     }
 
     private onChannelChangedHandler(appWindow: AppWindow, channel: ContextChannel | null, previousChannel: ContextChannel | null): void {
-        // Intentionally unawaited
+        // Events are 'fire-and-forget', so this is intentionally unawaited
         this._eventHandler.dispatchEventOnChannelChanged(appWindow, channel, previousChannel);
     }
 
@@ -147,7 +147,7 @@ export class Main {
 
             const sendContextPromise = windowsPromise.then(async (expectedWindows) => {
                 if (expectedWindows.length === 0) {
-                    throw new FDC3Error(OpenError.SendContextNoHandler, 'No context handler added');
+                    throw new FDC3Error(OpenError.SendContextNoHandler, 'Context provided, but no context handler added');
                 }
 
                 const [result] = await collateApiCallResults(expectedWindows.map((window) => this._contextHandler.send(window, context)));
@@ -280,9 +280,9 @@ export class Main {
         if (context) {
             await collateApiCallResults([this._contextHandler.send(appWindow, context)]).then(([result]) => {
                 if (result === CollateApiCallResultsResult.AllFailure) {
-                    console.warn('Error thrown by client attempting to handle context on window joining channel, swallowing error');
+                    console.warn(`Error thrown by client window ${appWindow.id} attempting to handle context on joining channel, swallowing error`);
                 } else if (result === CollateApiCallResultsResult.Timeout) {
-                    console.warn('Timeout waiting for client to handle context on window joining channel, swallowing error');
+                    console.warn(`Timeout waiting for client window ${appWindow.id} to handle context on joining channel, swallowing error`);
                 }
             });
         }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -147,7 +147,7 @@ export class Main {
 
             const sendContextPromise = windowsPromise.then(async (expectedWindows) => {
                 if (expectedWindows.length === 0) {
-                    throw new FDC3Error(OpenError.SendContextNoHandler, '');
+                    throw new FDC3Error(OpenError.SendContextNoHandler, 'No context handler added');
                 }
 
                 const [result] = await collateApiCallResults(expectedWindows.map((window) => this._contextHandler.send(window, context)));

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -151,9 +151,9 @@ export class Main {
 
                 const [result] = await collateApiCallResults(expectedWindows.map((window) => this._contextHandler.send(window, context)));
 
-                if (result === CollateApiCallResultsResult.AllFailure) {
+                if (result === CollateApiCallResultsResult.ALL_FAILURE) {
                     throw new FDC3Error(OpenError.SendContextError, 'Error(s) thrown by client attempting to handle context on app starting');
-                } else if (result === CollateApiCallResultsResult.Timeout) {
+                } else if (result === CollateApiCallResultsResult.TIMEOUT) {
                     throw new FDC3Error(OpenError.SendContextTimeout, 'Timeout waiting for client to handle context on app starting');
                 }
             });
@@ -278,9 +278,9 @@ export class Main {
 
         if (context) {
             await collateApiCallResults([this._contextHandler.send(appWindow, context)]).then(([result]) => {
-                if (result === CollateApiCallResultsResult.AllFailure) {
+                if (result === CollateApiCallResultsResult.ALL_FAILURE) {
                     console.warn(`Error thrown by client window ${appWindow.id} attempting to handle context on joining channel, swallowing error`);
-                } else if (result === CollateApiCallResultsResult.Timeout) {
+                } else if (result === CollateApiCallResultsResult.TIMEOUT) {
                     console.warn(`Timeout waiting for client window ${appWindow.id} to handle context on joining channel, swallowing error`);
                 }
             });

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -3,7 +3,7 @@ import {inject, injectable} from 'inversify';
 import {Identity} from 'openfin/_v2/main';
 import {ProviderIdentity} from 'openfin/_v2/api/interappbus/channel/channel';
 
-import {FDC3Error, OpenError, IdentityError} from '../client/errors';
+import {FDC3Error, OpenError, IdentityError, JoinError} from '../client/errors';
 import {RaiseIntentPayload, APIFromClientTopic, OpenPayload, FindIntentPayload, FindIntentsByContextPayload, BroadcastPayload, APIFromClient, AddIntentListenerPayload, RemoveIntentListenerPayload, GetSystemChannelsPayload, GetCurrentChannelPayload, ChannelGetMembersPayload, ChannelJoinPayload, ChannelTransport, SystemChannelTransport, GetChannelByIdPayload, ChannelBroadcastPayload, ChannelGetCurrentContextPayload, ChannelAddContextListenerPayload, ChannelRemoveContextListenerPayload, ChannelAddEventListenerPayload, ChannelRemoveEventListenerPayload, GetOrCreateAppChannelPayload, AppChannelTransport, AddContextListenerPayload, RemoveContextListenerPayload} from '../client/internal';
 import {AppIntent, IntentResolution, Application, Context} from '../client/main';
 import {parseIdentity, parseContext, parseChannelId, parseAppChannelName} from '../client/validation';
@@ -22,7 +22,7 @@ import {Intent} from './intents';
 import {ConfigStoreBinding} from './model/ConfigStore';
 import {ContextChannel} from './model/ContextChannel';
 import {Environment} from './model/Environment';
-import {collateResults} from './utils/async';
+import {collateResults, withTimeout} from './utils/async';
 
 @injectable()
 export class Main {
@@ -277,7 +277,16 @@ export class Main {
         const context = this._channelHandler.getChannelContext(channel);
 
         if (context) {
-            return this._contextHandler.send(appWindow, context);
+            let error = true;
+            const [timedout] = await withTimeout(5000, this._contextHandler.send(appWindow, context).catch(() => {
+                error = true;
+            }));
+
+            if (error) {
+                throw new FDC3Error(JoinError.SendContextError, '');
+            } else if (timedout) {
+                throw new FDC3Error(JoinError.SendContextTimeout, '');
+            }
         }
     }
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -22,7 +22,7 @@ import {Intent} from './intents';
 import {ConfigStoreBinding} from './model/ConfigStore';
 import {ContextChannel} from './model/ContextChannel';
 import {Environment} from './model/Environment';
-import {collateApiCallResults, CollateApiCallResultsResult} from './utils/async';
+import {collateClientCalls, CollateClientCallsResult} from './utils/helpers';
 
 @injectable()
 export class Main {
@@ -149,11 +149,11 @@ export class Main {
                     throw new FDC3Error(OpenError.SendContextNoHandler, 'Context provided, but no context handler added');
                 }
 
-                const [result] = await collateApiCallResults(expectedWindows.map((window) => this._contextHandler.send(window, context)));
+                const [result] = await collateClientCalls(expectedWindows.map((window) => this._contextHandler.send(window, context)));
 
-                if (result === CollateApiCallResultsResult.ALL_FAILURE) {
+                if (result === CollateClientCallsResult.ALL_FAILURE) {
                     throw new FDC3Error(OpenError.SendContextError, 'Error(s) thrown by client attempting to handle context on app starting');
-                } else if (result === CollateApiCallResultsResult.TIMEOUT) {
+                } else if (result === CollateClientCallsResult.TIMEOUT) {
                     throw new FDC3Error(OpenError.SendContextTimeout, 'Timeout waiting for client to handle context on app starting');
                 }
             });
@@ -277,10 +277,10 @@ export class Main {
         const context = this._channelHandler.getChannelContext(channel);
 
         if (context) {
-            await collateApiCallResults([this._contextHandler.send(appWindow, context)]).then(([result]) => {
-                if (result === CollateApiCallResultsResult.ALL_FAILURE) {
+            await collateClientCalls([this._contextHandler.send(appWindow, context)]).then(([result]) => {
+                if (result === CollateClientCallsResult.ALL_FAILURE) {
                     console.warn(`Error thrown by client window ${appWindow.id} attempting to handle context on joining channel, swallowing error`);
-                } else if (result === CollateApiCallResultsResult.TIMEOUT) {
+                } else if (result === CollateClientCallsResult.TIMEOUT) {
                     console.warn(`Timeout waiting for client window ${appWindow.id} to handle context on joining channel, swallowing error`);
                 }
             });

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -105,9 +105,8 @@ export class Main {
         console.log('Service Initialised');
     }
 
-    private onChannelChangedHandler(appWindow: AppWindow, channel: ContextChannel | null, previousChannel: ContextChannel | null): void {
-        // Events are 'fire-and-forget', so this is intentionally unawaited
-        this._eventHandler.dispatchEventOnChannelChanged(appWindow, channel, previousChannel);
+    private async onChannelChangedHandler(appWindow: AppWindow, channel: ContextChannel | null, previousChannel: ContextChannel | null): Promise<void> {
+        await this._eventHandler.dispatchEventOnChannelChanged(appWindow, channel, previousChannel);
     }
 
     private async open(payload: OpenPayload): Promise<void> {
@@ -274,7 +273,7 @@ export class Main {
 
         const channel = this._channelHandler.getChannelById(payload.id);
 
-        this._channelHandler.joinChannel(appWindow, channel);
+        await this._channelHandler.joinChannel(appWindow, channel);
         const context = this._channelHandler.getChannelContext(channel);
 
         if (context) {

--- a/src/provider/model/FinEnvironment.ts
+++ b/src/provider/model/FinEnvironment.ts
@@ -7,7 +7,7 @@ import {Signal} from 'openfin-service-signal';
 
 import {AsyncInit} from '../controller/AsyncInit';
 import {Application} from '../../client/main';
-import {FDC3Error, LaunchError} from '../../client/errors';
+import {FDC3Error, ApplicationError} from '../../client/errors';
 import {withTimeout} from '../utils/async';
 import {Timeouts} from '../constants';
 import {parseIdentity} from '../../client/validation';
@@ -50,14 +50,14 @@ export class FinEnvironment extends AsyncInit implements Environment {
             fin.Application.startFromManifest(appInfo.manifest).catch((e) => {
                 this.deregisterApplication({uuid});
 
-                throw new FDC3Error(LaunchError.ErrorOnLaunch, (e as Error).message);
+                throw new FDC3Error(ApplicationError.ErrorOnLaunch, (e as Error).message);
             })
         ).then((result) => {
             const [didTimeout] = result;
 
             if (didTimeout) {
                 this.deregisterApplication({uuid});
-                throw new FDC3Error(LaunchError.AppTimeout, `Timeout waiting for app '${appInfo.name}' to start from manifest`);
+                throw new FDC3Error(ApplicationError.AppTimeout, `Timeout waiting for app '${appInfo.name}' to start from manifest`);
             }
         });
 

--- a/src/provider/model/FinEnvironment.ts
+++ b/src/provider/model/FinEnvironment.ts
@@ -7,7 +7,7 @@ import {Signal} from 'openfin-service-signal';
 
 import {AsyncInit} from '../controller/AsyncInit';
 import {Application} from '../../client/main';
-import {FDC3Error, OpenError} from '../../client/errors';
+import {FDC3Error, LaunchError} from '../../client/errors';
 import {withTimeout} from '../utils/async';
 import {Timeouts} from '../constants';
 import {parseIdentity} from '../../client/validation';
@@ -50,14 +50,14 @@ export class FinEnvironment extends AsyncInit implements Environment {
             fin.Application.startFromManifest(appInfo.manifest).catch((e) => {
                 this.deregisterApplication({uuid});
 
-                throw new FDC3Error(OpenError.ErrorOnLaunch, (e as Error).message);
+                throw new FDC3Error(LaunchError.ErrorOnLaunch, (e as Error).message);
             })
         ).then((result) => {
             const [didTimeout] = result;
 
             if (didTimeout) {
                 this.deregisterApplication({uuid});
-                throw new FDC3Error(OpenError.AppTimeout, `Timeout waiting for app '${appInfo.name}' to start from manifest`);
+                throw new FDC3Error(LaunchError.AppTimeout, `Timeout waiting for app '${appInfo.name}' to start from manifest`);
             }
         });
 

--- a/src/provider/utils/async.ts
+++ b/src/provider/utils/async.ts
@@ -4,10 +4,10 @@ import {DeferredPromise} from '../common/DeferredPromise';
 import {Timeouts} from '../constants';
 
 export enum CollateApiCallResultsResult {
-    AnySuccess,
-    AllFailure,
-    Timeout,
-    NoCalls
+    ANY_SUCCESS,
+    ALL_FAILURE,
+    TIMEOUT,
+    NO_CALLS
 }
 
 /**
@@ -114,13 +114,13 @@ export async function collateApiCallResults<T = void>(promises: Promise<T>[]): P
     }))));
 
     if (promises.length === 0) {
-        return [CollateApiCallResultsResult.NoCalls, undefined];
+        return [CollateApiCallResultsResult.NO_CALLS, undefined];
     } else if (successes > 0) {
-        return [CollateApiCallResultsResult.AnySuccess, result!];
+        return [CollateApiCallResultsResult.ANY_SUCCESS, result!];
     } else if (failures > 0) {
-        return [CollateApiCallResultsResult.AllFailure, undefined];
+        return [CollateApiCallResultsResult.ALL_FAILURE, undefined];
     } else {
-        return [CollateApiCallResultsResult.Timeout, undefined];
+        return [CollateApiCallResultsResult.TIMEOUT, undefined];
     }
 }
 

--- a/src/provider/utils/async.ts
+++ b/src/provider/utils/async.ts
@@ -12,7 +12,8 @@ export enum CollateApiCallResultsResult {
 
 /**
  * Races a given promise against a timeout, and resolves to a `[didTimeout, value?]` tuple indicating
- * whether the timeout occurred, and the value the promise resolved to (if timeout didn't occur)
+ * whether the timeout occurred, and the value the promise resolved to (if timeout didn't occur).
+ *
  * @param timeoutMs Timeout period in ms
  * @param promise Promise to race against the timeout
  */
@@ -24,7 +25,8 @@ export function withTimeout<T>(timeoutMs: number, promise: Promise<T>): Promise<
 
 /**
  * Races a given promise against a timeout, and either resolves to the value the the promise resolved it, if it resolved before the
- * timeout, or rejects
+ * timeout, or rejects.
+ *
  * @param timeoutMs Timeout period in ms
  * @param promise Promise to race against the timeout
  */
@@ -34,7 +36,7 @@ export function withStrictTimeout<T>(timeoutMs: number, promise: Promise<T>, rej
 }
 
 /**
- * Returns a promise that resolves when the given predicate is true, evaluated immediately and each time the provided signal is fired
+ * Returns a promise that resolves when the given predicate is true, evaluated immediately and each time the provided signal is fired.
  *
  * @param signal When this signal is fired, the predicate is revaluated
  * @param predicate The predicate to evaluate
@@ -51,7 +53,7 @@ export function untilTrue<A extends any[]>(signal: Signal<A>, predicate: () => b
 
 /**
  * Returns a promise that resolves when the given signal is fired, and the given predicate evaluates to true when passed the arguments
- * recevied from the signal
+ * recevied from the signal.
  *
  * @param signal The signal to listen to
  * @param predicate The predicate to evaluate against arguments received from the signal
@@ -80,7 +82,7 @@ export function untilSignal<A extends any[]>(signal: Signal<A>, predicate: (...a
 /**
  * Attaches an empty `catch` block to a promise, then returns the original promise. This prevents rejection of the promise being logged as
  * a warning during tests, but does not otherwise change behaviour should the promise reject. This should be called for promises we expect
- * to reject under normal circumstances, but would not otherwise have a `catch` block attached
+ * to reject under normal circumstances, but would not otherwise have a `catch` block attached.
  *
  * @param promise The promise to attach the catch block to
  */
@@ -92,13 +94,13 @@ export function allowReject<T>(promise: Promise<T>): Promise<T> {
 /**
  * Takes multiple promises representing API calls, and reduces them to a single result. In the case that more than one promise resolves to
  * a result, the first to result will be used. Intented to be used when calling a client from the provider, to protect against a
- * misbehaving client
+ * misbehaving client.
  *
  * @param promises An array of promises
  */
 export async function collateApiCallResults<T = void>(promises: Promise<T>[]): Promise<[CollateApiCallResultsResult, T | undefined]> {
-    let failures = 0;
     let successes = 0;
+    let failures = 0;
 
     let result: T;
 

--- a/src/provider/utils/async.ts
+++ b/src/provider/utils/async.ts
@@ -97,7 +97,7 @@ export function allowReject<T>(promise: Promise<T>): Promise<T> {
  * @param promises An array of promises
  */
 export async function collateApiCallResults<T = void>(promises: Promise<T>[]): Promise<[CollateApiCallResultsResult, T | undefined]> {
-    let errors = 0;
+    let failures = 0;
     let successes = 0;
 
     let result: T;
@@ -108,14 +108,14 @@ export async function collateApiCallResults<T = void>(promises: Promise<T>[]): P
         }
         successes++;
     }, () => {
-        errors++;
+        failures++;
     }))));
 
     if (promises.length === 0) {
         return [CollateApiCallResultsResult.NoCalls, undefined];
     } else if (successes > 0) {
         return [CollateApiCallResultsResult.AnySuccess, result!];
-    } else if (errors > 0) {
+    } else if (failures > 0) {
         return [CollateApiCallResultsResult.AllFailure, undefined];
     } else {
         return [CollateApiCallResultsResult.Timeout, undefined];

--- a/src/provider/utils/async.ts
+++ b/src/provider/utils/async.ts
@@ -81,6 +81,30 @@ export function allowReject<T>(promise: Promise<T>): Promise<T> {
     return promise;
 }
 
+export async function collateResults<T = void>(timeout: number, promises: Promise<T>[]): Promise<['success' | 'error' | 'timeout', T | undefined]> {
+    let errors = 0;
+    let successes = 0;
+
+    let result: T;
+
+    await Promise.all(promises.map((promise) => withTimeout(5000, promise.then((promiseResult) => {
+        if (successes === 0) {
+            result = promiseResult;
+        }
+        successes++;
+    }, () => {
+        errors++;
+    }))));
+
+    if (successes > 0) {
+        return ['success', result!];
+    } else if (errors > 0) {
+        return ['error', undefined];
+    } else {
+        return ['timeout', undefined];
+    }
+}
+
 export async function asyncFilter<T>(arr: T[], callback: (x: T) => Promise<boolean>): Promise<T[]> {
     const result: T[] = [];
 

--- a/src/provider/utils/async.ts
+++ b/src/provider/utils/async.ts
@@ -81,7 +81,7 @@ export function allowReject<T>(promise: Promise<T>): Promise<T> {
     return promise;
 }
 
-export async function collateResults<T = void>(timeout: number, promises: Promise<T>[]): Promise<['success' | 'error' | 'timeout', T | undefined]> {
+export async function collateResults<T = void>(promises: Promise<T>[]): Promise<['success' | 'error' | 'timeout', T | undefined]> {
     let errors = 0;
     let successes = 0;
 

--- a/src/provider/utils/helpers.ts
+++ b/src/provider/utils/helpers.ts
@@ -38,7 +38,8 @@ export async function collateClientCalls<T = void>(promises: Promise<T>[]): Prom
             result = promiseResult;
         }
         successes++;
-    }, () => {
+    }, (e) => {
+        console.warn(`API call failed with error ${e.message}`);
         failures++;
     }))));
 

--- a/src/provider/utils/helpers.ts
+++ b/src/provider/utils/helpers.ts
@@ -3,7 +3,7 @@ import {Timeouts} from '../constants';
 
 import {withTimeout} from './async';
 
-export enum CollateClientCallsResult {
+export enum ClientCallsResult {
     ANY_SUCCESS,
     ALL_FAILURE,
     TIMEOUT,
@@ -27,7 +27,7 @@ export function checkCustomConfigField(app: Application, name: string): string |
  *
  * @param promises An array of promises
  */
-export async function collateClientCalls<T = void>(promises: Promise<T>[]): Promise<[CollateClientCallsResult, T | undefined]> {
+export async function collateClientCalls<T = void>(promises: Promise<T>[]): Promise<[ClientCallsResult, T | undefined]> {
     let successes = 0;
     let failures = 0;
 
@@ -43,12 +43,12 @@ export async function collateClientCalls<T = void>(promises: Promise<T>[]): Prom
     }))));
 
     if (promises.length === 0) {
-        return [CollateClientCallsResult.NO_CALLS, undefined];
+        return [ClientCallsResult.NO_CALLS, undefined];
     } else if (successes > 0) {
-        return [CollateClientCallsResult.ANY_SUCCESS, result!];
+        return [ClientCallsResult.ANY_SUCCESS, result!];
     } else if (failures > 0) {
-        return [CollateClientCallsResult.ALL_FAILURE, undefined];
+        return [ClientCallsResult.ALL_FAILURE, undefined];
     } else {
-        return [CollateClientCallsResult.TIMEOUT, undefined];
+        return [ClientCallsResult.TIMEOUT, undefined];
     }
 }

--- a/src/provider/utils/helpers.ts
+++ b/src/provider/utils/helpers.ts
@@ -1,4 +1,14 @@
 import {Application} from '../../client/directory';
+import {Timeouts} from '../constants';
+
+import {withTimeout} from './async';
+
+export enum CollateClientCallsResult {
+    ANY_SUCCESS,
+    ALL_FAILURE,
+    TIMEOUT,
+    NO_CALLS
+}
 
 export function checkCustomConfigField(app: Application, name: string): string | undefined {
     if (app.customConfig) {
@@ -8,4 +18,37 @@ export function checkCustomConfigField(app: Application, name: string): string |
         }
     }
     return undefined;
+}
+
+/**
+ * Takes multiple promises representing API calls, and reduces them to a single result. In the case that more than one promise resolves to
+ * a result, the first to result will be used. Intented to be used when calling a client from the provider, to protect against a
+ * misbehaving client.
+ *
+ * @param promises An array of promises
+ */
+export async function collateClientCalls<T = void>(promises: Promise<T>[]): Promise<[CollateClientCallsResult, T | undefined]> {
+    let successes = 0;
+    let failures = 0;
+
+    let result: T;
+
+    await Promise.all(promises.map((promise) => withTimeout(Timeouts.SERVICE_TO_CLIENT_API_CALL, promise.then((promiseResult) => {
+        if (successes === 0) {
+            result = promiseResult;
+        }
+        successes++;
+    }, () => {
+        failures++;
+    }))));
+
+    if (promises.length === 0) {
+        return [CollateClientCallsResult.NO_CALLS, undefined];
+    } else if (successes > 0) {
+        return [CollateClientCallsResult.ANY_SUCCESS, result!];
+    } else if (failures > 0) {
+        return [CollateClientCallsResult.ALL_FAILURE, undefined];
+    } else {
+        return [CollateClientCallsResult.TIMEOUT, undefined];
+    }
 }

--- a/test/demo/connection.inttest.ts
+++ b/test/demo/connection.inttest.ts
@@ -10,7 +10,7 @@ import {IntentHandler} from '../../src/provider/controller/IntentHandler';
 
 import * as fdc3Remote from './utils/fdc3RemoteExecution';
 import {fin} from './utils/fin';
-import {OFPuppeteerBrowser} from './utils/ofPuppeteer';
+import {OFPuppeteerBrowser, BaseWindowContext} from './utils/ofPuppeteer';
 import {setupTeardown, quitApps, TestAppData, NonDirectoryTestAppData} from './utils/common';
 import {testManagerIdentity, testAppInDirectory1, testAppWithPreregisteredListeners1, testAppNotInDirectory1, testAppNotInDirectoryNotFdc3, testAppNotFdc3} from './constants';
 import {RemoteChannel} from './utils/RemoteChannel';
@@ -18,7 +18,7 @@ import {delay, Duration} from './utils/delay';
 
 setupTeardown();
 
-type ProviderWindow = Window & {
+type ProviderWindow = BaseWindowContext & {
     model: Model;
     intentHandler: IntentHandler;
     channelHandler: ChannelHandler;

--- a/test/demo/contextChannels/broadcastOnWindow.inttest.ts
+++ b/test/demo/contextChannels/broadcastOnWindow.inttest.ts
@@ -8,6 +8,7 @@ import {fin} from '../utils/fin';
 import {setupTeardown, quitApps, setupStartNonDirectoryAppBookends} from '../utils/common';
 import {ChannelDescriptor, getChannel} from '../utils/channels';
 import {fakeAppChannelDescriptor} from '../utils/fakes';
+import {TestWindowContext} from '../utils/ofPuppeteer';
 
 /*
  * Tests top-level broadcast(), and addContextListener() calls, and how they interact with Channel.join()
@@ -62,10 +63,10 @@ describe.each(broadcastTestParams)(
 
             const channelChangingWindowListener = await fdc3Remote.addContextListener(channelChangingWindow);
 
-            // Broadcast our context on the blue channel
+            // Broadcast our context on the broadcast channel
             await fdc3Remote.broadcast(broadcastingWindow, testContext);
 
-            // Check our blue window received our test context
+            // Check our listening window received our test context
             await expect(channelChangingWindowListener).toHaveReceivedContexts([testContext]);
         }, appStartupTime * 2);
 
@@ -79,6 +80,40 @@ describe.each(broadcastTestParams)(
 
             // Check the default window did not received our test context
             await expect(listener).toHaveReceivedContexts([]);
+        }, appStartupTime * 2);
+
+        test('Broadcast resolves successfully even when a listener errors', async () => {
+            const [broadcastingWindow, listeningWindow] = await setupWindows(broadcastChannel, broadcastChannel);
+
+            // Setup an erroring listener
+            await fdc3Remote.ofBrowser.executeOnWindow(listeningWindow, function (this: TestWindowContext): void {
+                this.fdc3.addContextListener(() => {
+                    throw new Error('Context listener throwing error');
+                });
+            });
+
+            // Broadcast our context on the broadcast channel
+            await fdc3Remote.broadcast(broadcastingWindow, testContext);
+        }, appStartupTime * 2);
+
+        test('Context is recieved by listening window, even when a listener errors', async () => {
+            const [broadcastingWindow, listeningWindow] = await setupWindows(broadcastChannel, broadcastChannel);
+
+            // Setup an erroring listener
+            await fdc3Remote.ofBrowser.executeOnWindow(listeningWindow, function (this: TestWindowContext): void {
+                this.fdc3.addContextListener(() => {
+                    throw new Error('Context listener throwing error');
+                });
+            });
+
+            // Setup non-erroring listener
+            const listener = await fdc3Remote.addContextListener(listeningWindow);
+
+            // Broadcast our context on the broadcast channel
+            await fdc3Remote.broadcast(broadcastingWindow, testContext);
+
+            // Check the listening window received our test context
+            await expect(listener).toHaveReceivedContexts([testContext]);
         }, appStartupTime * 2);
     }
 );
@@ -109,7 +144,7 @@ const contextListenerTestParams = [
 ] as ContextListenerTestParam[];
 
 describe.each(contextListenerTestParams)('When adding a context listener to %s channel', (titleParam: string, broadcastChannel: ChannelDescriptor) => {
-    test('When the channel, has been broadcast on and has remained occupied, a context is received when joining', async () => {
+    test('When the channel has been broadcast on and has remained occupied, a context is received when joining', async () => {
         const [broadcastWindow, channelChangingWindow] = await setupWindows(broadcastChannel, 'default');
 
         // Broadcast our test context our channel to give the channel a cached context

--- a/test/demo/contextChannels/get.inttest.ts
+++ b/test/demo/contextChannels/get.inttest.ts
@@ -45,7 +45,7 @@ describe('When getting a channel by ID', () => {
         const getChannelByIdPromise = fdc3Remote.getChannelById(testManagerIdentity, 'non-existent-channel');
 
         await expect(getChannelByIdPromise).toThrowFDC3Error(
-            ChannelError.ChannelDoesNotExist,
+            ChannelError.ChannelWithIdDoesNotExist,
             'No channel with channelId: non-existent-channel'
         );
     });

--- a/test/demo/contextChannels/join.inttest.ts
+++ b/test/demo/contextChannels/join.inttest.ts
@@ -2,11 +2,12 @@
 import {Identity} from 'openfin/_v2/main';
 
 import {IdentityError, DEFAULT_CHANNEL_ID} from '../../../src/client/main';
-import {testManagerIdentity, appStartupTime, testAppNotInDirectory1, testAppNotInDirectoryNotFdc3, testAppInDirectory1, testAppInDirectory2} from '../constants';
+import {testManagerIdentity, appStartupTime, testAppNotInDirectory1, testAppNotInDirectoryNotFdc3, testAppInDirectory1, testAppInDirectory2, testAppUrl} from '../constants';
 import * as fdc3Remote from '../utils/fdc3RemoteExecution';
 import {RemoteChannel, RemoteChannelEventListener} from '../utils/RemoteChannel';
 import {setupTeardown, setupOpenDirectoryAppBookends, setupStartNonDirectoryAppBookends, quitApps, startNonDirectoryApp, startDirectoryApp} from '../utils/common';
-import {fakeAppChannelName} from '../utils/fakes';
+import {fakeAppChannelName, createFakeContext} from '../utils/fakes';
+import {TestWindowContext} from '../utils/ofPuppeteer';
 
 /*
  * Tests simple behaviour of Channel.getMembers() and the channel-changed and Channel events, before testing how they and getCurrentChannel()
@@ -263,6 +264,47 @@ describe('When joining a non-default channel', () => {
 
             // Check the joining window has the expected current channel
             await expect(fdc3Remote.getCurrentChannel(joiningApp)).resolves.toHaveProperty('channel', channel.channel);
+        });
+
+        test('When the channel has stored context, and the app has an erroring context listener, the promise resolves without error', async () => {
+            // Broadcast on our channel while populated to set a context
+            const childWindow = await fdc3Remote.createFinWindow(joiningApp, {url: testAppUrl, name: 'child-window'});
+            await channel.join(childWindow);
+            await channel.broadcast(createFakeContext());
+
+            // Setup an erroring listener
+            await fdc3Remote.ofBrowser.executeOnWindow(joiningApp, function (this: TestWindowContext): void {
+                this.fdc3.addContextListener(() => {
+                    throw new Error('Context listener throwing error');
+                });
+            });
+
+            // Join our channel
+            await channel.join(joiningApp);
+        });
+
+        test('When the channel has stored context, and the app has a mix of error and non-erroring context listeners, all listeners are \
+triggered, and the promise resolves without error', async () => {
+            // Broadcast on our channel while populated to set a context
+            const context = createFakeContext();
+            const childWindow = await fdc3Remote.createFinWindow(joiningApp, {url: testAppUrl, name: 'child-window'});
+            await channel.join(childWindow);
+            await channel.broadcast(context);
+
+            // Setup an erroring listener
+            await fdc3Remote.ofBrowser.executeOnWindow(joiningApp, function (this: TestWindowContext): void {
+                this.fdc3.addContextListener(() => {
+                    throw new Error('Context listener throwing error');
+                });
+            });
+
+            const listener = await fdc3Remote.addContextListener(joiningApp);
+
+            // Join our channel
+            await channel.join(joiningApp);
+
+            // Check the non-erroring listener received the context
+            await expect(listener).toHaveReceivedContexts([context]);
         });
 
         test(`The window is present when querying the members of the ${titleParam} channel and not the default channel`, async () => {

--- a/test/demo/open.inttest.ts
+++ b/test/demo/open.inttest.ts
@@ -109,7 +109,7 @@ describe('Opening applications with the FDC3 client', () => {
 
                     await fdc3Remote.ofBrowser.executeOnWindow(testAppInDirectory1, function (this: TestWindowContext): void {
                         this.fdc3.addContextListener(() => {
-                            throw new Error('Context listening throwing error');
+                            throw new Error('Context listener throwing error');
                         });
                     });
 
@@ -132,7 +132,7 @@ describe('Opening applications with the FDC3 client', () => {
                             });
 
                             this.fdc3.addContextListener(() => {
-                                throw new Error('Context listening throwing error');
+                                throw new Error('Context listener throwing error');
                             });
                         });
 
@@ -304,7 +304,7 @@ the context, and the service returns without error', async () => {
 
                 await fdc3Remote.ofBrowser.executeOnWindow(childWindow2, function (this: TestWindowContext): void {
                     this.fdc3.addContextListener(() => {
-                        throw new Error('Context listening throwing error');
+                        throw new Error('Context listener throwing error');
                     });
                 });
 

--- a/test/demo/open.inttest.ts
+++ b/test/demo/open.inttest.ts
@@ -211,7 +211,7 @@ triggered with the correct data', async () => {
                     // Add a listener
                     const listener = await fdc3Remote.addContextListener(testAppInDirectory1);
 
-                    await expect(openPromise).toThrowFDC3Error(OpenError.SendContextNoHandler, 'No context handler added');
+                    await expect(openPromise).toThrowFDC3Error(OpenError.SendContextNoHandler, 'Context provided, but no context handler added');
 
                     // Check the listener did not receive the context in open
                     await expect(listener).toHaveReceivedContexts([]);
@@ -406,12 +406,12 @@ and does not trigger the context listener of the already open app', async () => 
         });
 
         test('The promise resolves and the app opens', async () => {
-            await expect(openPromise).toThrowFDC3Error(OpenError.SendContextNoHandler, 'No context handler added');
+            await expect(openPromise).toThrowFDC3Error(OpenError.SendContextNoHandler, 'Context provided, but no context handler added');
             await expect(fin.Application.wrapSync(testAppDelayedPreregisterLong).isRunning()).resolves.toBe(true);
         });
 
         test('The context is not received by the listener', async () => {
-            await expect(openPromise).toThrowFDC3Error(OpenError.SendContextNoHandler, 'No context handler added');
+            await expect(openPromise).toThrowFDC3Error(OpenError.SendContextNoHandler, 'Context provided, but no context handler added');
 
             await delay(Duration.LONGER_THAN_APP_MATURITY);
             const preregisteredListener = await fdc3Remote.getRemoteContextListener(testAppDelayedPreregisterLong);

--- a/test/demo/open.inttest.ts
+++ b/test/demo/open.inttest.ts
@@ -2,7 +2,7 @@
 import 'jest';
 
 import {Context, OrganizationContext} from '../../src/client/main';
-import {OpenError} from '../../src/client/errors';
+import {OpenError, LaunchError} from '../../src/client/errors';
 import {Timeouts} from '../../src/provider/constants';
 
 import * as fdc3Remote from './utils/fdc3RemoteExecution';
@@ -282,7 +282,7 @@ and does not trigger the context listener of the already open app', async () => 
 
         // fin.Application.startFromManifest errors with this message when providing an inexistent manifest URL
         await expect(openPromise).toThrowFDC3Error(
-            OpenError.ErrorOnLaunch,
+            LaunchError.ErrorOnLaunch,
             /Failed to download resource\. Status code: 404/
         );
     });
@@ -293,7 +293,7 @@ and does not trigger the context listener of the already open app', async () => 
 
         // fin.Application.startFromManifest errors with this message when it times out trying to open an app
         await expect(openPromise).toThrowFDC3Error(
-            OpenError.AppTimeout,
+            LaunchError.AppTimeout,
             `Timeout waiting for app '${appName}' to start from manifest`
         );
     }, Timeouts.APP_START_FROM_MANIFEST + 2000);

--- a/test/demo/open.inttest.ts
+++ b/test/demo/open.inttest.ts
@@ -200,22 +200,25 @@ triggered with the correct data', async () => {
                     await expect(listener3).toHaveReceivedContexts([]);
                 });
 
-                test('When the app adds its listener after a long delay, the app opens but its context listener is not triggered', async () => {
+                test(
+                    'When the app adds its listener after a long delay, the app opens but the promise rejects and its context listener is not triggered',
+                    async () => {
                     // From the launcher app, call fdc3.open with a valid name and context
-                    const openPromise = allowReject(open(testAppInDirectory1.name, validContext));
+                        const openPromise = allowReject(open(testAppInDirectory1.name, validContext));
 
-                    // Wait a long delay after the app is running
-                    await waitForAppToBeRunning(testAppInDirectory1);
-                    await delay(Duration.LONGER_THAN_APP_MATURITY);
+                        // Wait a long delay after the app is running
+                        await waitForAppToBeRunning(testAppInDirectory1);
+                        await delay(Duration.LONGER_THAN_APP_MATURITY);
 
-                    // Add a listener
-                    const listener = await fdc3Remote.addContextListener(testAppInDirectory1);
+                        // Add a listener
+                        const listener = await fdc3Remote.addContextListener(testAppInDirectory1);
 
-                    await expect(openPromise).toThrowFDC3Error(OpenError.SendContextNoHandler, 'Context provided, but no context handler added');
+                        await expect(openPromise).toThrowFDC3Error(OpenError.SendContextNoHandler, 'Context provided, but no context handler added');
 
-                    // Check the listener did not receive the context in open
-                    await expect(listener).toHaveReceivedContexts([]);
-                }, appStartupTime + Duration.LONGER_THAN_APP_MATURITY);
+                        // Check the listener did not receive the context in open
+                        await expect(listener).toHaveReceivedContexts([]);
+                    }, appStartupTime + Duration.LONGER_THAN_APP_MATURITY
+                );
             });
 
             test('When passing a known app name but invalid context, the service returns an FDC3Error', async () => {

--- a/test/demo/open.inttest.ts
+++ b/test/demo/open.inttest.ts
@@ -391,7 +391,7 @@ and does not trigger the context listener of the already open app', async () => 
         });
     });
 
-    describe('When opening an app that takes longer than the timeout to register a listener', () => {
+    describe('When opening an app that takes longer than the timeout to register a context listener', () => {
         const testAppDelayedPreregisterLong = {uuid: 'test-app-delayed-preregister-long', name: 'test-app-delayed-preregister-long'};
         const validContext: OrganizationContext = {type: 'fdc3.organization', name: 'OpenFin', id: {default: 'openfin'}};
 
@@ -405,7 +405,7 @@ and does not trigger the context listener of the already open app', async () => 
             await quitApps(testAppDelayedPreregisterLong);
         });
 
-        test('The promise resolves and the app opens', async () => {
+        test('The promise rejects and the app opens', async () => {
             await expect(openPromise).toThrowFDC3Error(OpenError.SendContextNoHandler, 'Context provided, but no context handler added');
             await expect(fin.Application.wrapSync(testAppDelayedPreregisterLong).isRunning()).resolves.toBe(true);
         });

--- a/test/demo/open.inttest.ts
+++ b/test/demo/open.inttest.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/await-thenable */
 import 'jest';
 
+import {EventEmitter} from 'events';
+
 import {Context, OrganizationContext} from '../../src/client/main';
 import {OpenError, LaunchError} from '../../src/client/errors';
 import {Timeouts} from '../../src/provider/constants';
@@ -359,3 +361,21 @@ and does not trigger the context listener of the already open app', async () => 
 function open(appName: string, context?: Context | undefined): Promise<void> {
     return fdc3Remote.open(testManagerIdentity, appName, context);
 }
+
+test.only('wafrwefaesfesfe', async () => {
+    const emitter = new EventEmitter();
+
+    emitter.addListener('foo', () => {
+        throw new Error('waaaaa');
+    });
+
+    emitter.addListener('foo', () => {
+        throw new Error('baaaaaa');
+    });
+
+    try {
+        emitter.emit('foo');
+    } catch (e) {
+        console.log(e);
+    }
+});

--- a/test/demo/open.inttest.ts
+++ b/test/demo/open.inttest.ts
@@ -38,7 +38,7 @@ describe('Opening applications with the FDC3 client', () => {
                 await quitApps(testAppNotFdc3);
             });
 
-            test('When passing an unknown app name the service returns an FDC3Error', async () => {
+            test('When passing an unknown app name the promise rejects with an FDC3Error', async () => {
                 // From the launcher app, call fdc3.open with an unregistered name
                 const openPromise = open('invalid-app-name');
 
@@ -102,7 +102,7 @@ describe('Opening applications with the FDC3 client', () => {
                     await expect(preregisteredListener).toHaveReceivedContexts([validContext]);
                 });
 
-                test('When the app adds a listener that throws an error, the service returns an FDC3 error', async () => {
+                test('When the app adds a listener that throws an error, the promise rejects with an FDC3 error', async () => {
                     // From the launcher app, call fdc3.open with a valid name and context
                     const promise = allowReject(open(testAppInDirectory1.name, validContext));
                     await waitForAppToBeRunning(testAppInDirectory1);
@@ -120,7 +120,7 @@ describe('Opening applications with the FDC3 client', () => {
                 });
 
                 test(
-                    'When the app adds a mix of erroring and non-erroring listeners, all listeners recieve the context, and the service returns without error',
+                    'When the app adds a mix of erroring and non-erroring listeners, all listeners recieve the context, and the promise resolves',
                     async () => {
                         // From the launcher app, call fdc3.open with a valid name and context
                         const promise = allowReject(open(testAppInDirectory1.name, validContext));
@@ -221,13 +221,13 @@ triggered with the correct data', async () => {
                 );
             });
 
-            test('When passing a known app name but invalid context, the service returns an FDC3Error', async () => {
+            test('When passing a known app name but invalid context, the promise rejects with an FDC3Error', async () => {
                 const openPromise = open(testAppWithPreregisteredListeners1.name, invalidContext);
 
                 await expect(openPromise).rejects.toThrowError(new TypeError(`${JSON.stringify(invalidContext)} is not a valid Context`));
             });
 
-            test('When passing an unknown app name with any context the service returns an FDC3Error', async () => {
+            test('When passing an unknown app name with any context the promise rejects with an FDC3Error', async () => {
                 // From the launcher app, call fdc3.open with an invalid name and valid context
                 const openPromise = open('invalid-app-name', validContext);
 
@@ -297,7 +297,7 @@ the promise resolves', async () => {
             });
 
             test('When the running app has a mix of erroring and non-erroring listeners across multiple windows, all listeners recieve \
-the context, and the service returns without error', async () => {
+the context, and the promise resolves', async () => {
                 const listener1 = await fdc3Remote.getRemoteContextListener(testAppWithPreregisteredListeners1);
 
                 const childWindow1 = await fdc3Remote.createFinWindow(testAppWithPreregisteredListeners1, {url: testAppUrl, name: 'child-window-1'});

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -78,12 +78,12 @@ describe('Intent listeners and raising intents with a target', () => {
                     test('When the intent listener is added after a short delay, the targeted app opens and its listener is triggered \
 just once, with the correct context', async () => {
                         // Raise the intent but only add the intent listener after the some time
-                        await raiseDelayedIntentWithTarget(validIntent, testAppInDirectory1, 1500);
+                        await raiseDelayedIntentWithTarget(validIntent, testAppInDirectory1, Duration.SHORTER_THAN_APP_MATURITY);
 
                         // Since we are within listener handshake timeout, intent should be triggered correctly
                         const listener = await fdc3Remote.getRemoteIntentListener(testAppInDirectory1, validIntent.type);
                         await expect(listener).toHaveReceivedContexts([validIntent.context]);
-                    }, appStartupTime + 1500);
+                    }, appStartupTime + Duration.SHORTER_THAN_APP_MATURITY);
 
                     test('When the intent listener is added on a child window, the targeted app opens and its listener is triggered \
 just once, with the correct context', async () => {

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -2,7 +2,7 @@
 import 'jest';
 import 'reflect-metadata';
 
-import {ResolveError} from '../../../src/client/errors';
+import {RaiseIntentError} from '../../../src/client/errors';
 import {fin} from '../utils/fin';
 import * as fdc3Remote from '../utils/fdc3RemoteExecution';
 import {delay, Duration} from '../utils/delay';
@@ -49,7 +49,7 @@ describe('Intent listeners and raising intents with a target', () => {
             describe('When the target is *not* registered to accept the raised intent', () => {
                 test('When calling raiseIntent the promise rejects with an FDC3Error', async () => {
                     await expect(raiseIntent(nonExistentIntent, testAppInDirectory1)).toThrowFDC3Error(
-                        ResolveError.TargetAppDoesNotHandleIntent,
+                        RaiseIntentError.TargetAppDoesNotHandleIntent,
                         `App '${testAppInDirectory1.name}' does not handle intent '${nonExistentIntent.type}' with context '${nonExistentIntent.context.type}'`
                     );
                 });
@@ -131,8 +131,8 @@ listener to be added', async () => {
                         );
 
                         await expect(raiseIntentPromise).toThrowFDC3Error(
-                            ResolveError.IntentTimeout,
-                            `Timeout waiting for intent listener to be added for intent: ${validIntent.type}`
+                            RaiseIntentError.SendIntentNoHandler,
+                            `No intent handler added for intent: ${validIntent.type}`
                         );
                     }, appStartupTime + Duration.LONGER_THAN_APP_MATURITY);
                 });
@@ -149,7 +149,7 @@ listener to be added', async () => {
         describe('When the target is not running', () => {
             test('When calling raiseIntent the promise rejects with an FDC3Error', async () => {
                 await expect(raiseIntent(validIntent, testAppNotInDirectory1)).toThrowFDC3Error(
-                    ResolveError.TargetAppNotAvailable,
+                    RaiseIntentError.TargetAppNotAvailable,
                     `Couldn't resolve intent target '${testAppNotInDirectory1.name}'. No matching app in directory or currently running.`
                 );
             });
@@ -160,7 +160,7 @@ listener to be added', async () => {
 
             test('When calling raiseIntent the promise rejects with an FDC3Error', async () => {
                 await expect(raiseIntent(validIntent, testAppNotInDirectoryNotFdc3)).toThrowFDC3Error(
-                    ResolveError.TargetAppDoesNotHandleIntent,
+                    RaiseIntentError.TargetAppDoesNotHandleIntent,
                     `App '${testAppNotInDirectoryNotFdc3.name}' does not handle intent '${validIntent.type}' with context '${validIntent.context.type}'`
                 );
             });
@@ -177,7 +177,7 @@ function setupCommonRunningAppTests(testAppData: TestAppData): void {
     describe('When the target has *not* registered listeners for the raised intent', () => {
         test('When calling raiseIntent the promise rejects with an FDC3Error', async () => {
             await expect(raiseIntent(nonExistentIntent, testAppData)).toThrowFDC3Error(
-                ResolveError.TargetAppDoesNotHandleIntent,
+                RaiseIntentError.TargetAppDoesNotHandleIntent,
                 `App '${testAppData.name}' does not handle intent '${nonExistentIntent.type}' with context '${nonExistentIntent.context.type}'`
             );
         });
@@ -244,7 +244,7 @@ only the first listener is triggered', async () => {
             const expectedRaise = expect(raiseIntent(validIntent, testAppData));
 
             await expectedRaise.toThrowFDC3Error(
-                ResolveError.TargetAppDoesNotHandleIntent,
+                RaiseIntentError.TargetAppDoesNotHandleIntent,
                 `App '${testAppData.name}' does not handle intent '${validIntent.type}' with context '${validIntent.context.type}'`
             );
 

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -263,7 +263,6 @@ listeners are triggered with the correct context and the promise resolves', asyn
     });
 
     test('When calling addIntentListener for the first time, the promise resolves and there are no errors', async () => {
-        // eslint-disable-next-line
         await expect(fdc3Remote.addIntentListener(testAppData, validIntent.type)).resolves.not.toThrow();
     });
 

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -211,21 +211,19 @@ FDC3Error', async () => {
             );
         });
 
-        test(
-            'When an intent listener is added that throws and error, when calling raiseIntent from another app, the promise rejects with an FDC3Error',
-            async () => {
-                await fdc3Remote.ofBrowser.executeOnWindow(testAppData, function (this: TestWindowContext, intentRemote: IntentType): void {
-                    this.fdc3.addIntentListener(intentRemote, async () => {
-                        throw new Error('Intent listener throwing error');
-                    });
-                }, validIntent.type);
+        test('When an intent listener is added that throws and error, when calling raiseIntent from another app, the promise rejects with \
+an FDC3Error', async () => {
+            await fdc3Remote.ofBrowser.executeOnWindow(testAppData, function (this: TestWindowContext, intentRemote: IntentType): void {
+                this.fdc3.addIntentListener(intentRemote, async () => {
+                    throw new Error('Intent listener throwing error');
+                });
+            }, validIntent.type);
 
-                await expect(raiseIntent(validIntent, testAppData)).toThrowFDC3Error(
-                    RaiseIntentError.SendIntentError,
-                    'Error(s) thrown by client attempting to handle intent'
-                );
-            }
-        );
+            await expect(raiseIntent(validIntent, testAppData)).toThrowFDC3Error(
+                RaiseIntentError.SendIntentError,
+                'Error(s) thrown by client attempting to handle intent'
+            );
+        });
 
         test('When a mix of erroring and non-erroring intent listeners are added, when calling raiseIntent from another app, all listeners are triggered with \
 the correct context and the promise resolves', async () => {
@@ -243,19 +241,19 @@ the correct context and the promise resolves', async () => {
         });
 
         test('When a mix of erroring and non-erroring intent listeners are added across multiple windows, when calling raiseIntent from another app, all \
-listeners are triggered with the correct context and the promise resolve', async () => {
+listeners are triggered with the correct context and the promise resolves', async () => {
             const listener1 = await fdc3Remote.addIntentListener(testAppData, validIntent.type);
 
             const childWindow1 = await fdc3Remote.createFinWindow(testAppData, {url: testAppUrl, name: 'child-window-1'});
             const childWindow2 = await fdc3Remote.createFinWindow(testAppData, {url: testAppUrl, name: 'child-window-2'});
 
-            const listener2 = await fdc3Remote.addIntentListener(childWindow1, validIntent.type);
-
-            await fdc3Remote.ofBrowser.executeOnWindow(childWindow2, function (this: TestWindowContext, intentRemote: IntentType): void {
+            await fdc3Remote.ofBrowser.executeOnWindow(childWindow1, function (this: TestWindowContext, intentRemote: IntentType): void {
                 this.fdc3.addIntentListener(intentRemote, () => {
                     throw new Error('Intent listener throwing error');
                 });
             }, validIntent.type);
+
+            const listener2 = await fdc3Remote.addIntentListener(childWindow2, validIntent.type);
 
             await raiseIntent(validIntent, testAppData);
 

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -9,7 +9,8 @@ import {delay, Duration} from '../utils/delay';
 import {TestAppData, DirectoryTestAppData, setupOpenDirectoryAppBookends, setupStartNonDirectoryAppBookends, setupTeardown, setupQuitAppAfterEach, waitForAppToBeRunning} from '../utils/common';
 import {appStartupTime, testManagerIdentity, testAppInDirectory1, testAppNotInDirectory1, testAppWithPreregisteredListeners1, testAppNotInDirectoryNotFdc3, testAppUrl} from '../constants';
 import {allowReject} from '../../../src/provider/utils/async';
-import {Intent} from '../../../src/provider/intents';
+import {Intent, IntentType} from '../../../src/provider/intents';
+import {TestWindowContext} from '../utils/ofPuppeteer';
 
 /**
  * Intent registered by `testAppWithPreregisteredListeners1` right after opening
@@ -192,6 +193,74 @@ the child listener is triggered exactly once with the correct context', async ()
             await raiseIntent(validIntent, testAppData);
 
             await expect(childListener).toHaveReceivedContexts([validIntent.context]);
+        });
+
+        test('When an intent listener is added that takes a long time to resolve, when calling raiseIntent from another app, the promise rejects with an \
+FDC3Error', async () => {
+            await fdc3Remote.ofBrowser.executeOnWindow(testAppData, function (this: TestWindowContext, intentRemote: IntentType, delayRemote: number): void {
+                this.fdc3.addIntentListener(intentRemote, async () => {
+                    await new Promise((res) => {
+                        this.setTimeout(res, delayRemote);
+                    });
+                });
+            }, validIntent.type, Duration.LONGER_THAN_SERVICE_TO_CLIENT_API_CALL_TIMEOUT);
+
+            await expect(raiseIntent(validIntent, testAppData)).toThrowFDC3Error(
+                RaiseIntentError.SendIntentTimeout,
+                'Timeout waiting for client to handle intent'
+            );
+        });
+
+        test(
+            'When an intent listener is added that throws and error, when calling raiseIntent from another app, the promise rejects with an FDC3Error',
+            async () => {
+                await fdc3Remote.ofBrowser.executeOnWindow(testAppData, function (this: TestWindowContext, intentRemote: IntentType): void {
+                    this.fdc3.addIntentListener(intentRemote, async () => {
+                        throw new Error('Intent listener throwing error');
+                    });
+                }, validIntent.type);
+
+                await expect(raiseIntent(validIntent, testAppData)).toThrowFDC3Error(
+                    RaiseIntentError.SendIntentError,
+                    'Error(s) thrown by client attempting to handle intent'
+                );
+            }
+        );
+
+        test('When a mix of erroring and non-erroring intent listeners are added, when calling raiseIntent from another app, all listeners are triggered with \
+the correct context and the promise resolves', async () => {
+            await fdc3Remote.ofBrowser.executeOnWindow(testAppData, function (this: TestWindowContext, intentRemote: IntentType): void {
+                this.fdc3.addIntentListener(intentRemote, async () => {
+                    throw new Error('Intent listener throwing error');
+                });
+            }, validIntent.type);
+
+            const listener = await fdc3Remote.addIntentListener(testAppData, validIntent.type);
+
+            await raiseIntent(validIntent, testAppData);
+
+            await expect(listener).toHaveReceivedContexts([validIntent.context]);
+        });
+
+        test('When a mix of erroring and non-erroring intent listeners are added across multiple windows, when calling raiseIntent from another app, all \
+listeners are triggered with the correct context and the promise resolve', async () => {
+            const listener1 = await fdc3Remote.addIntentListener(testAppData, validIntent.type);
+
+            const childWindow1 = await fdc3Remote.createFinWindow(testAppData, {url: testAppUrl, name: 'child-window-1'});
+            const childWindow2 = await fdc3Remote.createFinWindow(testAppData, {url: testAppUrl, name: 'child-window-2'});
+
+            const listener2 = await fdc3Remote.addIntentListener(childWindow1, validIntent.type);
+
+            await fdc3Remote.ofBrowser.executeOnWindow(childWindow2, function (this: TestWindowContext, intentRemote: IntentType): void {
+                this.fdc3.addIntentListener(intentRemote, () => {
+                    throw new Error('Intent listener throwing error');
+                });
+            }, validIntent.type);
+
+            await raiseIntent(validIntent, testAppData);
+
+            await expect(listener1).toHaveReceivedContexts([validIntent.context]);
+            await expect(listener2).toHaveReceivedContexts([validIntent.context]);
         });
     });
 

--- a/test/demo/raiseIntent/withoutTarget.inttest.ts
+++ b/test/demo/raiseIntent/withoutTarget.inttest.ts
@@ -1,7 +1,7 @@
 import 'jest';
 import 'reflect-metadata';
 
-import {ResolveError} from '../../../src/client/errors';
+import {RaiseIntentError} from '../../../src/client/errors';
 import {RESOLVER_IDENTITY} from '../../../src/provider/utils/constants';
 import {fin} from '../utils/fin';
 import * as fdc3Remote from '../utils/fdc3RemoteExecution';
@@ -97,7 +97,7 @@ describe('Intent listeners and raising intents without a target', () => {
                         describe('When calling raiseIntent from another app, the resolver is displayed with both apps.', () => {
                             test('When closing the resolver, an error is thrown', async () => {
                                 await expect(raiseIntentExpectResolverAndClose(uniqueIntent)).toThrowFDC3Error(
-                                    ResolveError.ResolverClosedOrCancelled,
+                                    RaiseIntentError.ResolverClosedOrCancelled,
                                     'Resolver closed or cancelled'
                                 );
                             });
@@ -130,8 +130,8 @@ describe('Intent listeners and raising intents without a target', () => {
                 describe('When the directory app does not register the intent listener after opening', () => {
                     test('When calling raiseIntent from another app, the app opens but it times out waiting for the listener to be added', async () => {
                         await expect(raiseIntentPromise).toThrowFDC3Error(
-                            ResolveError.IntentTimeout,
-                            `Timeout waiting for intent listener to be added for intent: ${uniqueIntent.type}`
+                            RaiseIntentError.SendIntentNoHandler,
+                            `No intent handler added for intent: ${uniqueIntent.type}`
                         );
                     });
                 });
@@ -180,8 +180,8 @@ app, the app opens but the promise rejects', async () => {
                         const listener = await fdc3Remote.addIntentListener(testAppWithUniqueIntent, uniqueIntent.type);
 
                         await expect(raiseIntentPromise).toThrowFDC3Error(
-                            ResolveError.IntentTimeout,
-                            `Timeout waiting for intent listener to be added for intent: ${uniqueIntent.type}`
+                            RaiseIntentError.SendIntentNoHandler,
+                            `No intent handler added for intent: ${uniqueIntent.type}`
                         );
 
                         await expect(listener).toHaveReceivedContexts([]);
@@ -195,7 +195,7 @@ app, the app opens but the promise rejects', async () => {
                 describe('When calling raiseIntent from another app, the resolver is displayed with the directory + ad-hoc app', () => {
                     test('When closing the resolver, an error is thrown', async () => {
                         await expect(raiseIntentExpectResolverAndClose(uniqueIntent)).toThrowFDC3Error(
-                            ResolveError.ResolverClosedOrCancelled,
+                            RaiseIntentError.ResolverClosedOrCancelled,
                             'Resolver closed or cancelled'
                         );
                     });
@@ -228,7 +228,7 @@ app, the app opens but the promise rejects', async () => {
         describe('When calling raiseIntent from another app, the resolver is displayed with multiple apps', () => {
             test('When closing the resolver, an error is thrown', async () => {
                 await expect(raiseIntentExpectResolverAndClose(intentInManyApps)).toThrowFDC3Error(
-                    ResolveError.ResolverClosedOrCancelled,
+                    RaiseIntentError.ResolverClosedOrCancelled,
                     'Resolver closed or cancelled'
                 );
             });
@@ -330,7 +330,7 @@ function setupNoDirectoryAppCanHandleIntentTests(intent: Intent): void {
     describe('And no running ad-hoc apps with listeners registered for the raised intent', () => {
         test('When calling raiseIntent the promise rejects with an FDC3Error', async () => {
             await expect(raiseIntent(intent)).toThrowFDC3Error(
-                ResolveError.NoAppsFound,
+                RaiseIntentError.NoAppsFound,
                 'No applications available to handle this intent'
             );
         });
@@ -350,7 +350,7 @@ function setupNoDirectoryAppCanHandleIntentTests(intent: Intent): void {
             test('When calling unsubscribe from the intent listener, then calling raiseIntent from another app, it errors', async () => {
                 await listener1.value.unsubscribe();
                 await expect(raiseIntent(intent)).toThrowFDC3Error(
-                    ResolveError.NoAppsFound,
+                    RaiseIntentError.NoAppsFound,
                     'No applications available to handle this intent'
                 );
             });
@@ -362,7 +362,7 @@ function setupNoDirectoryAppCanHandleIntentTests(intent: Intent): void {
             describe('When calling raiseIntent, the resolver is displayed with both apps', () => {
                 test('When closing the resolver, an error is thrown', async () => {
                     await expect(raiseIntentExpectResolverAndClose(intent)).toThrowFDC3Error(
-                        ResolveError.ResolverClosedOrCancelled,
+                        RaiseIntentError.ResolverClosedOrCancelled,
                         'Resolver closed or cancelled'
                     );
                 });

--- a/test/demo/utils/delay.ts
+++ b/test/demo/utils/delay.ts
@@ -13,6 +13,7 @@ export enum Duration {
     PAGE_NAVIGATE = 500,
     SHORTER_THAN_APP_MATURITY = 2000,
     LONGER_THAN_APP_MATURITY = 6000,
+    LONGER_THAN_SERVICE_TO_CLIENT_API_CALL_TIMEOUT = 6000,
     // Should only be used when this isn't captured in the promise returned by an API call, or we have good reason to not await the API call
     API_CALL = 250,
     // Certain events involve a handshake between client and service, but the API call is unawaited on the client, so we use this delay to

--- a/test/demo/utils/fakes.ts
+++ b/test/demo/utils/fakes.ts
@@ -1,7 +1,7 @@
 import {Identity} from 'openfin/_v2/main';
 
 import {Application, AppDirIntent} from '../../../src/client/directory';
-import {ChannelId} from '../../../src/client/main';
+import {ChannelId, Context} from '../../../src/client/main';
 
 import {ChannelDescriptor} from './channels';
 
@@ -30,6 +30,13 @@ export function createFakeIntent(options: Partial<AppDirIntent> = {}): AppDirInt
     return {
         name: `intent-name-${idString()}`,
         customConfig: [],
+        ...options
+    };
+}
+
+export function createFakeContext(options: Partial<Context> = {}): Context {
+    return {
+        type: createFakeContextType(),
         ...options
     };
 }

--- a/test/demo/utils/ofPuppeteer.ts
+++ b/test/demo/utils/ofPuppeteer.ts
@@ -2,12 +2,54 @@ import {Fin, Identity} from 'openfin/_v2/main';
 import {Browser, Page, JSHandle} from 'puppeteer';
 import {connect} from 'hadouken-js-adapter';
 
+import {Context, ContextListener, IntentListener, Channel} from '../../../src/client/main';
+import {Events, ChannelEvents} from '../../../src/client/internal';
+import {IntentType} from '../../../src/provider/intents';
+
 import {uuidv4} from './uuidv4';
 
 declare const global: NodeJS.Global & {__BROWSER__: Browser};
 
+export interface TestWindowEventListener {
+    // eslint-disable-next-line
+    handler: (payload: any) => void;
+    unsubscribe: () => void;
+}
+
+export interface TestWindowChannelEventListener {
+    // eslint-disable-next-line
+    handler: (payload: any) => void;
+    unsubscribe: () => void;
+}
+
+export type TestWindowContext = Window&{
+    fin: Fin;
+    fdc3: typeof import('../../../src/client/main');
+
+    contextListeners: ContextListener[];
+    intentListeners: {[intent: string]: IntentListener[]};
+    eventListeners: TestWindowEventListener[];
+    channelEventListeners: TestWindowChannelEventListener[];
+
+    channelTransports: {[id: string]: TestChannelTransport};
+
+    receivedContexts: {listenerID: number; context: Context}[];
+    receivedEvents: {listenerID: number; payload: Events}[];
+    receivedIntents: {listenerID: number; intent: IntentType; context: Context}[];
+    receivedChannelEvents: {listenerID: number; payload: ChannelEvents}[];
+
+    errorHandler(error: Error): never;
+    serializeChannel(channel: Channel): TestChannelTransport;
+};
+
 // Helper type. Works better with puppeteer than the builtin Function type
 type AnyFunction = (...args: any[]) => any;
+
+export interface TestChannelTransport {
+    id: string;
+    channel: Channel;
+    constructor: string;
+}
 
 export type BaseWindowContext = Window & {fin: Fin};
 

--- a/test/demo/utils/uuidv4.ts
+++ b/test/demo/utils/uuidv4.ts
@@ -1,0 +1,6 @@
+/**
+ * Generates a random uuid based on math.random and the system time
+ */
+export function uuidv4() {
+    return (Math.random().toString(36).substring(2) + Date.now().toString(36));
+}

--- a/test/provider/ChannelHandler.unittest.ts
+++ b/test/provider/ChannelHandler.unittest.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
     (mockModel as PartiallyWritable<typeof mockModel, 'onWindowRemoved'>).onWindowRemoved = new Signal<[AppWindow]>();
 
     channelHandler = new ChannelHandler(mockModel);
-    channelHandler.onChannelChanged.add((appWindow: AppWindow, channel: ContextChannel | null, previousChannel: ContextChannel | null) => {
+    channelHandler.onChannelChanged.add(async (appWindow: AppWindow, channel: ContextChannel | null, previousChannel: ContextChannel | null) => {
         mockOnChannelChanged(appWindow, channel, previousChannel);
     });
 });
@@ -151,54 +151,54 @@ describe('When setting the last broadcast context for a channel', () => {
 });
 
 describe('When joining a channel', () => {
-    it('ChannelHandler sets the channel of the window', () => {
+    it('ChannelHandler sets the channel of the window', async () => {
         const testChannel1 = createMockChannel({id: 'test-1'});
         const testChannel2 = createMockChannel({id: 'test-2'});
 
         const testWindow = createMockAppWindow({channel: testChannel1});
         setModelWindows([testWindow]);
 
-        channelHandler.joinChannel(testWindow, testChannel2);
+        await channelHandler.joinChannel(testWindow, testChannel2);
 
         expect(testWindow.channel).toEqual(testChannel2);
     });
 
-    it('If changing channel, ChannelHandler fires it onChannelChanged signal', () => {
+    it('If changing channel, ChannelHandler fires it onChannelChanged signal', async () => {
         const testChannel1 = createMockChannel({id: 'test-1'});
         const testChannel2 = createMockChannel({id: 'test-2'});
 
         const testWindow = createMockAppWindow({channel: testChannel1});
         setModelWindows([testWindow]);
 
-        channelHandler.joinChannel(testWindow, testChannel2);
+        await channelHandler.joinChannel(testWindow, testChannel2);
 
         expect(mockOnChannelChanged.mock.calls).toEqual([[testWindow, testChannel2, testChannel1]]);
     });
 
-    it('If not changing channel, ChannelHandler fires a onChannelChanged signal', () => {
+    it('If not changing channel, ChannelHandler fires a onChannelChanged signal', async () => {
         const testChannel = createMockChannel();
 
         const testWindow = createMockAppWindow({channel: testChannel});
         setModelWindows([testWindow]);
 
-        channelHandler.joinChannel(testWindow, testChannel);
+        await channelHandler.joinChannel(testWindow, testChannel);
 
         expect(mockOnChannelChanged).toBeCalledTimes(0);
     });
 
-    it('If the previous channel is now empty, ChannelHandler clears the context of the previous channel', () => {
+    it('If the previous channel is now empty, ChannelHandler clears the context of the previous channel', async () => {
         const testChannel1 = createMockChannel();
         const testChannel2 = createMockChannel();
 
         const testWindow = createMockAppWindow({channel: testChannel1});
         setModelWindows([testWindow]);
 
-        channelHandler.joinChannel(testWindow, testChannel2);
+        await channelHandler.joinChannel(testWindow, testChannel2);
 
         expect(testChannel1.clearStoredContext).toBeCalledTimes(1);
     });
 
-    it('If the previous channel is still populated, ChannelHandler does not clear the context of the previous channel', () => {
+    it('If the previous channel is still populated, ChannelHandler does not clear the context of the previous channel', async () => {
         const testChannel1 = createMockChannel();
         const testChannel2 = createMockChannel();
 
@@ -207,7 +207,7 @@ describe('When joining a channel', () => {
 
         setModelWindows([testWindow1, testWindow2]);
 
-        channelHandler.joinChannel(testWindow1, testChannel2);
+        await channelHandler.joinChannel(testWindow1, testChannel2);
 
         expect(testChannel1.clearStoredContext).toBeCalledTimes(0);
     });

--- a/test/provider/ChannelHandler.unittest.ts
+++ b/test/provider/ChannelHandler.unittest.ts
@@ -79,7 +79,7 @@ describe('When geting channel by ID', () => {
 
         expect(() => {
             channelHandler.getChannelById('test');
-        }).toThrowFDC3Error(ChannelError.ChannelDoesNotExist, 'No channel with channelId: test');
+        }).toThrowFDC3Error(ChannelError.ChannelWithIdDoesNotExist, 'No channel with channelId: test');
     });
 });
 

--- a/test/provider/ContextHandler.unittest.ts
+++ b/test/provider/ContextHandler.unittest.ts
@@ -31,7 +31,6 @@ beforeEach(() => {
     getterMock(mockModel, 'apps').mockReturnValue([]);
 
     mockApiHandler.dispatch.mockReturnValue(Promise.resolve());
-    mockApiHandler.publish.mockReturnValue([Promise.resolve()]);
 
     contextHandler = new ContextHandler(mockApiHandler, mockChannelHandler, mockModel);
 });

--- a/test/provider/ContextHandler.unittest.ts
+++ b/test/provider/ContextHandler.unittest.ts
@@ -30,6 +30,9 @@ beforeEach(() => {
     getterMock(mockModel, 'windows').mockReturnValue(mockWindows);
     getterMock(mockModel, 'apps').mockReturnValue([]);
 
+    mockApiHandler.dispatch.mockReturnValue(Promise.resolve());
+    mockApiHandler.publish.mockReturnValue([Promise.resolve()]);
+
     contextHandler = new ContextHandler(mockApiHandler, mockChannelHandler, mockModel);
 });
 


### PR DESCRIPTION
This PR
- Modifies error codes to match actual failure cases, rather than FDC3 spec (which kinda didn't make sense). Any reconciliation is saved for SERVICE-561. We new have a group of call-specific error codes, and a group of "generic" error codes
- Uses new error codes in `open` and `raiseIntent`
- Guards against calls from the service to the client erroring or failing to return quickly, generally taking the PoV that if one context/intent handler succeeds, even if others fail/timeout, that's enough to be a success
- Updates `ofPuppeteer.ts` from Notifications (I was going to use the new function mounting method, but then didn't, but it seemed worth keeping this change)

I'll need to re-work some things if this goes in after PR-165