### PR TITLE
[N/A] Prevent context listener breaking change

### DIFF
--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -139,12 +139,12 @@ export class APIHandler<T extends Enum> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private onConnectionHandler(identity: Identity, payload?: any): void {
         const id = getId(identity);
-        const semver: SemVer = SemVer.parse(payload && payload.version);
+        const semVer: SemVer = SemVer.parse(payload && payload.version);
 
-        this._clientVersions[id] = semver;
+        this._clientVersions[id] = semVer;
 
-        if (semver.isValid) {
-            console.log(`connection from client: ${identity.name}, version: ${semver.version}`);
+        if (semVer.valid) {
+            console.log(`connection from client: ${identity.name}, version: ${semVer.version}`);
         } else {
             console.log(`connection from client: ${identity.name}, unable to determine version`);
         }

--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -6,6 +6,9 @@ import {Signal} from 'openfin-service-signal';
 
 import {SERVICE_CHANNEL, serializeError} from '../client/internal';
 
+import {getId} from './utils/getId';
+import {SemVer} from './utils/SemVer';
+
 /**
  * Semantic type definition.
  *
@@ -66,6 +69,11 @@ export class APIHandler<T extends Enum> {
     public readonly onDisconnection: Signal<[Identity]> = new Signal();
 
     private _providerChannel!: ChannelProvider;
+    private readonly _clientVersions: {[key: string]: SemVer};
+
+    constructor() {
+        this._clientVersions = {};
+    }
 
     public isClientConnection(identity: Identity): boolean {
         return !!this._providerChannel && this._providerChannel.connections.some((conn: Identity) => {
@@ -75,6 +83,10 @@ export class APIHandler<T extends Enum> {
 
     public getClientConnections(): Identity[] {
         return this._providerChannel.connections;
+    }
+
+    public getClientVersion(id: string): SemVer {
+        return this._clientVersions[id] || SemVer.parse('');
     }
 
     public dispatch(to: Identity, action: string, payload: any): Promise<any> {
@@ -126,8 +138,13 @@ export class APIHandler<T extends Enum> {
     // TODO?: Remove the need for this any by defining connection payload type?
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private onConnectionHandler(identity: Identity, payload?: any): void {
-        if (payload && payload.version && payload.version.length > 0) {
-            console.log(`connection from client: ${identity.name}, version: ${payload.version}`);
+        const id = getId(identity);
+        const semver: SemVer = SemVer.parse(payload && payload.version);
+
+        this._clientVersions[id] = semver;
+
+        if (semver.isValid) {
+            console.log(`connection from client: ${identity.name}, version: ${semver.version}`);
         } else {
             console.log(`connection from client: ${identity.name}, unable to determine version`);
         }
@@ -139,7 +156,10 @@ export class APIHandler<T extends Enum> {
         });
     }
 
-    private onDisconnectionHandler(app: Identity): void {
-        this.onDisconnection.emit(app);
+    private onDisconnectionHandler(identity: Identity): void {
+        const id = getId(identity);
+        delete this._clientVersions[id];
+
+        this.onDisconnection.emit(identity);
     }
 }

--- a/src/provider/model/FinAppConnection.ts
+++ b/src/provider/model/FinAppConnection.ts
@@ -1,5 +1,7 @@
 import {Identity} from 'openfin/_v2/main';
 
+import {SemVer} from '../utils/SemVer';
+
 import {AppConnectionBase} from './AppConnection';
 import {ContextChannel} from './ContextChannel';
 import {EntityType} from './Environment';
@@ -8,8 +10,8 @@ import {LiveApp} from './LiveApp';
 export class FinAppConnection extends AppConnectionBase {
     private readonly _identity: Identity;
 
-    constructor(identity: Identity, entityType: EntityType, liveApp: LiveApp, channel: ContextChannel, entityNumber: number) {
-        super(identity, entityType, liveApp.appInfo!, liveApp.waitForAppMature(), channel, entityNumber);
+    constructor(identity: Identity, entityType: EntityType, version: SemVer, liveApp: LiveApp, channel: ContextChannel, entityNumber: number) {
+        super(identity, entityType, version, liveApp.appInfo!, liveApp.waitForAppMature(), channel, entityNumber);
 
         this._identity = identity;
     }

--- a/src/provider/model/FinAppWindow.ts
+++ b/src/provider/model/FinAppWindow.ts
@@ -1,5 +1,7 @@
 import {Identity, Window} from 'openfin/_v2/main';
 
+import {SemVer} from '../utils/SemVer';
+
 import {AppConnectionBase} from './AppConnection';
 import {ContextChannel} from './ContextChannel';
 import {LiveApp} from './LiveApp';
@@ -8,8 +10,8 @@ import {EntityType} from './Environment';
 export class FinAppWindow extends AppConnectionBase {
     private readonly _window: Window;
 
-    constructor(identity: Identity, entityType: EntityType, liveApp: LiveApp, channel: ContextChannel, entityNumber: number) {
-        super(identity, entityType, liveApp.appInfo!, liveApp.waitForAppMature(), channel, entityNumber);
+    constructor(identity: Identity, entityType: EntityType, version: SemVer, liveApp: LiveApp, channel: ContextChannel, entityNumber: number) {
+        super(identity, entityType, version, liveApp.appInfo!, liveApp.waitForAppMature(), channel, entityNumber);
 
         this._window = fin.Window.wrapSync(identity);
     }

--- a/src/provider/model/FinEnvironment.ts
+++ b/src/provider/model/FinEnvironment.ts
@@ -124,6 +124,7 @@ export class FinEnvironment extends AsyncInit implements Environment {
             const applicationInfo = await application.getInfo();
             let {name: title, icon} = applicationInfo.initialOptions as ApplicationOption;
 
+            // `manifest` is defined as required property but actually optional. Not present on programmatically-launched apps.
             if (applicationInfo.manifest) {
                 const {shortcut, startup_app: startupApp} = applicationInfo.manifest as OFManifest;
                 title = (shortcut && shortcut.name) || startupApp.name || startupApp.uuid;
@@ -136,6 +137,7 @@ export class FinEnvironment extends AsyncInit implements Environment {
                 title,
                 icons: icon ? [{icon}] : undefined,
                 manifestType: 'openfin',
+                // `manifestUrl` is defined as required property but actually optional. Not present on programmatically-launched apps.
                 manifest: applicationInfo.manifestUrl || ''
             };
         }

--- a/src/provider/utils/SemVer.ts
+++ b/src/provider/utils/SemVer.ts
@@ -28,7 +28,9 @@ export class SemVer {
     }
 
     public static parse(version: string | SemVer): SemVer {
-        if (typeof version === 'string' || version === null || version === undefined) {
+        if (version instanceof SemVer) {
+            return version;
+        } else {
             let semver = SemVer.CACHE[version];
 
             if (!semver) {
@@ -37,14 +39,12 @@ export class SemVer {
             }
 
             return semver;
-        } else {
-            return version;
         }
     }
 
     public readonly version: string;
     public readonly type: SemVerType;
-    public readonly components: Readonly<[number, number, number, ...(string|number)[]]>;
+    public readonly components: Readonly<[number, number, number, ...(string | number)[]]>;
 
     constructor(version: string) {
         const match = version && SemVer.REGEX_SEMVER.exec(version);
@@ -68,11 +68,11 @@ export class SemVer {
         }
     }
 
-    public get isValid(): boolean {
+    public get valid(): boolean {
         return this.type === SemVerType.VALID;
     }
 
-    public compare(operator: Operator, other: string|SemVer, defaultIfInvalid: boolean = false): boolean {
+    public compare(operator: Operator, other: string | SemVer, defaultIfInvalid: boolean = false): boolean {
         other = SemVer.parse(other);
 
         if (this.type === SemVerType.VALID && other.type === SemVerType.VALID) {

--- a/src/provider/utils/SemVer.ts
+++ b/src/provider/utils/SemVer.ts
@@ -112,4 +112,3 @@ export class SemVer {
         }
     }
 }
-(window as any).SemVer = SemVer;

--- a/src/provider/utils/SemVer.ts
+++ b/src/provider/utils/SemVer.ts
@@ -76,12 +76,17 @@ export class SemVer {
         other = SemVer.parse(other);
 
         if (this.type === SemVerType.VALID && other.type === SemVerType.VALID) {
+            // Based on operator, determine if inputs are allowed to be equal
+            const allowEqual = operator.endsWith('=');
+
+            // Given the existance of caching, there's a decent chance we don't actually need to compare anything
+            if (this === other) {
+                return allowEqual;
+            }
+
             // Based on the operator, determine which of the inputs should be smaller
             const {components: min} = operator.startsWith('<') ? this : other;
             const {components: max} = operator.startsWith('<') ? other : this;
-
-            // Based on operator, determine if inputs are allowed to be equal
-            const allowEqual = operator.endsWith('=');
 
             // Check each component of the inputs in turn
             const minCount = min.length;

--- a/src/provider/utils/SemVer.ts
+++ b/src/provider/utils/SemVer.ts
@@ -1,0 +1,115 @@
+export enum SemVerType {
+    VALID = 'VALID',
+    INVALID = 'INVALID',
+    UNKNOWN = 'UNKNOWN'
+}
+
+export enum Operator {
+    LESS_THAN = '<',
+    GREATER_THAN = '>',
+    LESS_THAN_OR_EQUAL = '<=',
+    GREATER_THAN_OR_EQUAL = '>='
+}
+
+/**
+ * Util for comparing semantic version numbers.
+ *
+ * NOTE: Only parses the major, minor, patch and pre-release parts of the semver string - build metadata is ignored.
+ *
+ * Spec: https://semver.org/
+ */
+export class SemVer {
+    private static readonly REGEX_SEMVER: RegExp = /(\d+)\.(\d+)\.(\d+)(?:-([^-+]+))?/;
+    private static readonly REGEX_INTEGER: RegExp = /^\d+$/;
+    private static readonly CACHE: {[key: string]: SemVer} = {};
+
+    public static compare(a: string | SemVer, operator: Operator, b: string | SemVer): boolean {
+        return SemVer.parse(a).compare(operator, b);
+    }
+
+    public static parse(version: string | SemVer): SemVer {
+        if (typeof version === 'string' || version === null || version === undefined) {
+            let semver = SemVer.CACHE[version];
+
+            if (!semver) {
+                semver = new SemVer(version);
+                SemVer.CACHE[version] = semver;
+            }
+
+            return semver;
+        } else {
+            return version;
+        }
+    }
+
+    public readonly version: string;
+    public readonly type: SemVerType;
+    public readonly components: Readonly<[number, number, number, ...(string|number)[]]>;
+
+    constructor(version: string) {
+        const match = version && SemVer.REGEX_SEMVER.exec(version);
+
+        if (match) {
+            const [, major, minor, patch, preRelease = ''] = match;
+            const preReleaseComponents = preRelease.split('.').map((component) => {
+                if (SemVer.REGEX_INTEGER.test(component)) {
+                    return parseInt(component);
+                } else {
+                    return component;
+                }
+            }).filter((component) => !!component);
+            this.version = version;
+            this.components = [parseInt(major), parseInt(minor), parseInt(patch), ...preReleaseComponents];
+            this.type = SemVerType.VALID;
+        } else {
+            this.components = [0, 0, 0];
+            this.type = version ? SemVerType.INVALID : SemVerType.UNKNOWN;
+            this.version = this.type;
+        }
+    }
+
+    public get isValid(): boolean {
+        return this.type === SemVerType.VALID;
+    }
+
+    public compare(operator: Operator, other: string|SemVer, defaultIfInvalid: boolean = false): boolean {
+        other = SemVer.parse(other);
+
+        if (this.type === SemVerType.VALID && other.type === SemVerType.VALID) {
+            // Based on the operator, determine which of the inputs should be smaller
+            const {components: min} = operator.startsWith('<') ? this : other;
+            const {components: max} = operator.startsWith('<') ? other : this;
+
+            // Based on operator, determine if inputs are allowed to be equal
+            const allowEqual = operator.endsWith('=');
+
+            // Check each component of the inputs in turn
+            const minCount = min.length;
+            const maxCount = max.length;
+            const componentCount = Math.min(minCount, maxCount);
+            for (let i = 0; i < componentCount; i++) {
+                if (min[i] !== max[i]) {
+                    if (typeof min[i] !== typeof max[i]) {
+                        // When comparing numeric and non-numeric pre-release parts, non-numeric take precedence
+                        return typeof min[i] === 'number';
+                    } else {
+                        return min[i] < max[i];
+                    }
+                }
+            }
+
+            if (minCount === maxCount) {
+                return allowEqual;
+            } else if (componentCount === 3) {
+                // When mixing 'release' and 'pre-release', the 'release' version takes precedence
+                return minCount > maxCount;
+            } else {
+                // When comparing two 'pre-release' versions, the version with most parts takes precedence
+                return minCount < maxCount;
+            }
+        } else {
+            return defaultIfInvalid;
+        }
+    }
+}
+(window as any).SemVer = SemVer;

--- a/src/provider/utils/SemVer.ts
+++ b/src/provider/utils/SemVer.ts
@@ -31,14 +31,14 @@ export class SemVer {
         if (version instanceof SemVer) {
             return version;
         } else {
-            let semver = SemVer.CACHE[version];
+            let semVer = SemVer.CACHE[version];
 
-            if (!semver) {
-                semver = new SemVer(version);
-                SemVer.CACHE[version] = semver;
+            if (!semVer) {
+                semVer = new SemVer(version);
+                SemVer.CACHE[version] = semVer;
             }
 
-            return semver;
+            return semVer;
         }
     }
 

--- a/test/provider/AppWindow.unittest.ts
+++ b/test/provider/AppWindow.unittest.ts
@@ -6,10 +6,11 @@ import {DeferredPromise} from 'openfin-service-async';
 import {createMockChannel} from '../mocks';
 import {useMockTime, unmockTime, advanceTime, resolvePromiseChain} from '../utils/unit/time';
 import {Application} from '../../src/client/main';
+import {Timeouts} from '../../src/provider/constants';
 import {AppConnectionBase} from '../../src/provider/model/AppConnection';
 import {ContextChannel} from '../../src/provider/model/ContextChannel';
 import {EntityType} from '../../src/provider/model/Environment';
-import {Timeouts} from '../../src/provider/constants';
+import {SemVer} from '../../src/provider/utils/SemVer';
 
 class TestAppWindow extends AppConnectionBase {
     public bringToFront: jest.Mock<Promise<void>, []> = jest.fn<Promise<void>, []>();
@@ -17,8 +18,8 @@ class TestAppWindow extends AppConnectionBase {
 
     private readonly _identity: Readonly<Identity>;
 
-    constructor(identity: Identity, appInfo: Application, maturityPromise: Promise<void>, channel: ContextChannel, entityNumber: number) {
-        super(identity, EntityType.WINDOW, appInfo, maturityPromise, channel, entityNumber);
+    constructor(identity: Identity, version: SemVer, appInfo: Application, maturityPromise: Promise<void>, channel: ContextChannel, entityNumber: number) {
+        super(identity, EntityType.WINDOW, version, appInfo, maturityPromise, channel, entityNumber);
 
         this._identity = identity;
     }
@@ -31,6 +32,7 @@ class TestAppWindow extends AppConnectionBase {
 const mockChannel = createMockChannel();
 
 const fakeIdentity = {uuid: 'test', name: 'test'};
+const fakeVersion = new SemVer('1.0.0');
 const fakeAppInfo: Application = {
     appId: 'test',
     name: 'Test App',
@@ -46,7 +48,7 @@ describe('When querying if a window has a context listener', () => {
     let testAppWindow: TestAppWindow;
 
     beforeEach(() => {
-        testAppWindow = new TestAppWindow(fakeIdentity, fakeAppInfo, createMaturityPromise(), mockChannel, 0);
+        testAppWindow = new TestAppWindow(fakeIdentity, fakeVersion, fakeAppInfo, createMaturityPromise(), mockChannel, 0);
     });
 
     test('A freshly-initialized window returns false', () => {
@@ -78,7 +80,7 @@ describe('When querying if a window has a context listener', () => {
     });
 
     test('The state of one TestAppWindow does not affect another', () => {
-        const secondTestAppWindow = new TestAppWindow(fakeIdentity, fakeAppInfo, createMaturityPromise(), mockChannel, 0);
+        const secondTestAppWindow = new TestAppWindow(fakeIdentity, fakeVersion, fakeAppInfo, createMaturityPromise(), mockChannel, 0);
         secondTestAppWindow.addContextListener();
 
         expect(testAppWindow.hasContextListener()).toBe(false);
@@ -92,7 +94,7 @@ describe('When querying if a window is ready to receive contexts', () => {
         // All tests in this section will use fake timers to allow us to control the Promise races precisely
         useMockTime();
 
-        testAppWindow = new TestAppWindow(fakeIdentity, fakeAppInfo, createMaturityPromise(), mockChannel, 0);
+        testAppWindow = new TestAppWindow(fakeIdentity, fakeVersion, fakeAppInfo, createMaturityPromise(), mockChannel, 0);
     });
 
     afterEach(() => {

--- a/test/provider/SemVer.unittest.ts
+++ b/test/provider/SemVer.unittest.ts
@@ -1,4 +1,4 @@
-import {SemVer, SemVerType} from '../../src/provider/utils/SemVer';
+import {SemVer, SemVerType, Operator} from '../../src/provider/utils/SemVer';
 
 // A semver string, or a string and which part of the string will actually match the regex (i.e. with any junk pre/post text removed)
 type SemVerInput = string | [string, string];
@@ -54,7 +54,7 @@ describe('When parsing semver strings', () => {
         createSemVerTests(instanceData);
     });
 
-    describe('When string contains a version number and pre-release version', () => {
+    describe('When string contains a pre-release version', () => {
         const instanceData: SemVerInstance[] = [
             // Valid version numbers
             ['1.0.0-alpha', SemVerType.VALID, [1, 0, 0, 'alpha']],
@@ -85,7 +85,7 @@ describe('When parsing semver strings', () => {
         createSemVerTests(instanceData);
     });
 
-    describe('When string contains a version number, pre-release version and build metadata', () => {
+    describe('When string contains build metadata', () => {
         const instanceData: SemVerInstance[] = [
             // With just version number
             [['1.0.0+0', '1.0.0'], SemVerType.VALID, [1, 0, 0]],
@@ -109,5 +109,88 @@ describe('When parsing semver strings', () => {
         ];
 
         createSemVerTests(instanceData);
+    });
+
+    describe('When input is empty or missing', () => {
+        const instanceData: SemVerInstance[] = [
+            ['', SemVerType.UNKNOWN, [0, 0, 0]],
+            [null!, SemVerType.UNKNOWN, [0, 0, 0]],
+            [undefined!, SemVerType.UNKNOWN, [0, 0, 0]]
+        ];
+
+        it.each(instanceData)('%s is parsed as %s', (input, type, components) => {
+            const semVer = new SemVer(input as string);
+
+            expect(semVer.type).toEqual(type);
+            expect(semVer.components).toEqual(components);
+            expect(semVer.version).toEqual(type);
+        });
+    });
+});
+
+describe('When comparing SemVer objects', () => {
+    // Builds a set of sample SemVer's, in precedence order.
+    // Pre-release examples taken from semver spec: https://semver.org/#spec-item-11
+    const versions = ['0.0.0', '0.0.1', '0.0.2', '0.0.10', '0.1.0', '0.1.1', '0.1.10', '0.2.0', '0.2.10', '1.0.0', '2.0.0', '10.0.0'];
+    const preReleaseStrings = ['-alpha', '-alpha.1', '-alpha.beta', '-beta', '-beta.2', '-beta.11', '-rc.1', ''];
+    const samples: SemVer[] = versions.reduce<string[]>((output, version) => {
+        return output.concat(...preReleaseStrings.map((preRelease) => `${version}${preRelease}`));
+    }, []).map((version) => new SemVer(version));
+
+    const operators: Operator[] = [
+        Operator.LESS_THAN,
+        Operator.GREATER_THAN,
+        Operator.LESS_THAN_OR_EQUAL,
+        Operator.GREATER_THAN_OR_EQUAL
+    ];
+
+    function createOperatorTests(operator: Operator, inequalityResult: boolean, equalityResult: boolean): void {
+        for (let i = 0, count = samples.length; i < count; i++) {
+            if (i >= 1) {
+                expect(samples[i - 1].compare(operator, samples[i])).toEqual(inequalityResult);
+                expect(samples[i].compare(operator, samples[i - 1])).toEqual(!inequalityResult);
+            }
+            expect(samples[i].compare(operator, samples[i])).toEqual(equalityResult);
+        }
+    }
+
+    it('A comparison with an UNKNOWN SemVer always returns false', () => {
+        const unknown = new SemVer(null!);
+
+        expect(unknown.type).toEqual(SemVerType.UNKNOWN);
+        samples.forEach((sample) => {
+            operators.forEach((operator) => {
+                expect(sample.compare(operator, unknown)).toEqual(false);
+                expect(unknown.compare(operator, sample)).toEqual(false);
+            });
+        });
+    });
+
+    it('A comparison with an INVALID SemVer always returns false', () => {
+        const invalid = new SemVer('x');
+
+        expect(invalid.type).toEqual(SemVerType.INVALID);
+        samples.forEach((sample) => {
+            operators.forEach((operator) => {
+                expect(sample.compare(operator, invalid)).toEqual(false);
+                expect(invalid.compare(operator, sample)).toEqual(false);
+            });
+        });
+    });
+
+    it('The LESS_THAN operator respects SemVer precedence rules', () => {
+        createOperatorTests(Operator.LESS_THAN, true, false);
+    });
+
+    it('The LESS_THAN_OR_EQUAL operator respects SemVer precedence rules', () => {
+        createOperatorTests(Operator.LESS_THAN_OR_EQUAL, true, true);
+    });
+
+    it('The GREATER_THAN operator respects SemVer precedence rules', () => {
+        createOperatorTests(Operator.GREATER_THAN, false, false);
+    });
+
+    it('The GREATER_THAN_OR_EQUAL operator respects SemVer precedence rules', () => {
+        createOperatorTests(Operator.GREATER_THAN_OR_EQUAL, false, true);
     });
 });

--- a/test/provider/SemVer.unittest.ts
+++ b/test/provider/SemVer.unittest.ts
@@ -1,0 +1,113 @@
+import {SemVer, SemVerType} from '../../src/provider/utils/SemVer';
+
+// A semver string, or a string and which part of the string will actually match the regex (i.e. with any junk pre/post text removed)
+type SemVerInput = string | [string, string];
+// Major, Minor and Patch numbers, followed by the segments of a dot-separated 'pre-release' version string.
+type SemVerComponents = [number, number, number, ...(string | number)[]];
+type SemVerInstance = [SemVerInput, SemVerType, SemVerComponents];
+
+function createSemVerTests(instanceData: SemVerInstance[]): void {
+    function doTest(input: string, output: string, type: SemVerType, components: SemVerComponents): void {
+        const semVer = new SemVer(input);
+
+        expect(semVer.type).toEqual(type);
+        expect(semVer.components).toEqual(components);
+        expect(semVer.version).toEqual(type === SemVerType.VALID ? output : type);
+    }
+
+    it.each(instanceData)('%s is parsed as %s', (input, type, components) => {
+        const [versionString, expectedVersionString] = typeof input === 'string' ? [input, input] : input;
+        doTest(versionString, expectedVersionString, type, components);
+    });
+
+    it.each(instanceData)('%s is parsed as %s, when surrounded by unrelated text', (input, type, components) => {
+        const [versionString, expectedVersionString] = typeof input === 'string' ? [input, input] : input;
+        doTest(`foo v${versionString}! bar`, expectedVersionString, type, components);
+    });
+}
+
+describe('When parsing semver strings', () => {
+    describe('When string contains only a version number', () => {
+        const instanceData: SemVerInstance[] = [
+            // Valid version numbers
+            ['0.0.0', SemVerType.VALID, [0, 0, 0]],
+            ['0.0.1', SemVerType.VALID, [0, 0, 1]],
+            ['0.1.0', SemVerType.VALID, [0, 1, 0]],
+            ['1.0.0', SemVerType.VALID, [1, 0, 0]],
+            ['99.99.99', SemVerType.VALID, [99, 99, 99]],
+            ['10.2.99', SemVerType.VALID, [10, 2, 99]],
+
+            // Wrong number of components
+            ['0', SemVerType.INVALID, [0, 0, 0]],
+            ['10', SemVerType.INVALID, [0, 0, 0]],
+            ['0.0', SemVerType.INVALID, [0, 0, 0]],
+            ['10.10', SemVerType.INVALID, [0, 0, 0]],
+            ['0.0.0.0', SemVerType.INVALID, [0, 0, 0]],
+            ['10.10.10.10', SemVerType.INVALID, [0, 0, 0]],
+
+            // Invalid numbers
+            ['-1.0.0', SemVerType.INVALID, [0, 0, 0]],
+            ['0.-1.0', SemVerType.INVALID, [0, 0, 0]],
+            ['0.0.-1', SemVerType.INVALID, [0, 0, 0]]
+        ];
+
+        createSemVerTests(instanceData);
+    });
+
+    describe('When string contains a version number and pre-release version', () => {
+        const instanceData: SemVerInstance[] = [
+            // Valid version numbers
+            ['1.0.0-alpha', SemVerType.VALID, [1, 0, 0, 'alpha']],
+            ['1.0.0-0', SemVerType.VALID, [1, 0, 0, 0]],
+            ['1.0.0-1', SemVerType.VALID, [1, 0, 0, 1]],
+            ['1.0.0-10', SemVerType.VALID, [1, 0, 0, 10]],
+            ['1.0.0-1.0', SemVerType.VALID, [1, 0, 0, 1, 0]],
+            ['1.0.0-1.1', SemVerType.VALID, [1, 0, 0, 1, 1]],
+            ['1.0.0-1.10', SemVerType.VALID, [1, 0, 0, 1, 10]],
+            ['1.0.0-alpha.0', SemVerType.VALID, [1, 0, 0, 'alpha', 0]],
+            ['1.0.0-alpha.1', SemVerType.VALID, [1, 0, 0, 'alpha', 1]],
+            ['1.0.0-alpha.beta', SemVerType.VALID, [1, 0, 0, 'alpha', 'beta']],
+            ['1.0.0-beta.1', SemVerType.VALID, [1, 0, 0, 'beta', 1]],
+
+            // Whole string is invalid, but contains a smaller, valid SemVer
+            [['1.0.0-alpha-1', '1.0.0-alpha'], SemVerType.VALID, [1, 0, 0, 'alpha']],
+
+            // Wrong number of components
+            ['1.0.0-', SemVerType.INVALID, [0, 0, 0]],
+            ['1.0.0-+1', SemVerType.INVALID, [0, 0, 0]],
+
+            // Invalid characters
+            ['1.0.0-', SemVerType.INVALID, [0, 0, 0]],
+            ['0.-1.0', SemVerType.INVALID, [0, 0, 0]],
+            ['0.0.-1', SemVerType.INVALID, [0, 0, 0]]
+        ];
+
+        createSemVerTests(instanceData);
+    });
+
+    describe('When string contains a version number, pre-release version and build metadata', () => {
+        const instanceData: SemVerInstance[] = [
+            // With just version number
+            [['1.0.0+0', '1.0.0'], SemVerType.VALID, [1, 0, 0]],
+            [['1.0.0+1', '1.0.0'], SemVerType.VALID, [1, 0, 0]],
+            [['1.0.0+100', '1.0.0'], SemVerType.VALID, [1, 0, 0]],
+            [['1.0.0+alpha', '1.0.0'], SemVerType.VALID, [1, 0, 0]],
+            [['1.0.0+0.0', '1.0.0'], SemVerType.VALID, [1, 0, 0]],
+            [['1.0.0+0.100', '1.0.0'], SemVerType.VALID, [1, 0, 0]],
+            [['1.0.0+alpha.0', '1.0.0'], SemVerType.VALID, [1, 0, 0]],
+            [['1.0.0+20200101.1200', '1.0.0'], SemVerType.VALID, [1, 0, 0]],
+
+            // With version number and pre-release version
+            [['1.0.0-alpha.100+0', '1.0.0-alpha.100'], SemVerType.VALID, [1, 0, 0, 'alpha', 100]],
+            [['1.0.0-alpha.100+1', '1.0.0-alpha.100'], SemVerType.VALID, [1, 0, 0, 'alpha', 100]],
+            [['1.0.0-alpha.100+100', '1.0.0-alpha.100'], SemVerType.VALID, [1, 0, 0, 'alpha', 100]],
+            [['1.0.0-alpha.100+alpha', '1.0.0-alpha.100'], SemVerType.VALID, [1, 0, 0, 'alpha', 100]],
+            [['1.0.0-alpha.100+0.0', '1.0.0-alpha.100'], SemVerType.VALID, [1, 0, 0, 'alpha', 100]],
+            [['1.0.0-alpha.100+0.100', '1.0.0-alpha.100'], SemVerType.VALID, [1, 0, 0, 'alpha', 100]],
+            [['1.0.0-alpha.100+alpha.0', '1.0.0-alpha.100'], SemVerType.VALID, [1, 0, 0, 'alpha', 100]],
+            [['1.0.0-alpha.100+20200101.1200', '1.0.0-alpha.100'], SemVerType.VALID, [1, 0, 0, 'alpha', 100]]
+        ];
+
+        createSemVerTests(instanceData);
+    });
+});


### PR DESCRIPTION
Provider now tracks client version of each connection. Will assume that any pre-0.2.1 client connections always have context listeners - this prevents the recent addition of context listener handshakes from being a breaking change.