### PR TITLE
[SERVICE-794][SERVICE-793] Reconnect to service on disconnect

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -49,24 +49,20 @@ const hasDOMContentLoaded = new DeferredPromise<void>();
 
 if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', () => {
-        initialize();
+        hasDOMContentLoaded.resolve();
+        if (typeof fin !== 'undefined') {
+            getServicePromise();
+
+            fin.InterApplicationBus.Channel.onChannelDisconnect((event: OpenFinChannelConnectionEvent) => {
+                const {uuid, name, channelName} = event;
+                if (uuid === getServiceIdentity().uuid && name === getServiceIdentity().name && channelName === getServiceChannel()) {
+                    channelPromise = null;
+                }
+            });
+        } else {
+            channelPromise = Promise.reject(new Error('fin is not defined. The openfin-fdc3 module is only intended for use in an OpenFin application.'));
+        }
     });
-}
-
-function initialize() {
-    hasDOMContentLoaded.resolve();
-    if (typeof fin !== 'undefined') {
-        getServicePromise();
-
-        fin.InterApplicationBus.Channel.onChannelDisconnect((event: OpenFinChannelConnectionEvent) => {
-            const {uuid, name, channelName} = event;
-            if (uuid === getServiceIdentity().uuid && name === getServiceIdentity().name && channelName === getServiceChannel()) {
-                channelPromise = null;
-            }
-        });
-    } else {
-        channelPromise = Promise.reject(new Error('fin is not defined. The openfin-fdc3 module is only intended for use in an OpenFin application.'));
-    }
 }
 
 export async function getServicePromise(): Promise<ChannelClient> {

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -83,11 +83,11 @@ export async function getServicePromise(): Promise<ChannelClient> {
                         wait: true,
                         payload: {version: PACKAGE_VERSION}
                     });
-                    console.log('Connected');
                     // Register service listeners
                     channel.register('WARN', (payload: unknown) => console.warn(payload));  // tslint:disable-line:no-any
                     // Any unregistered action will simply return false
                     channel.setDefaultAction(() => false);
+
                     if (!hasDisconnectListener) {
                         channel.onDisconnection(() => {
                             reconnect = true;
@@ -96,9 +96,11 @@ export async function getServicePromise(): Promise<ChannelClient> {
                         });
                         hasDisconnectListener = true;
                     }
+
                     if (reconnect) {
                         onReconnect.emit();
                     }
+
                     resolve(channel);
                 }
             });

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -48,9 +48,6 @@ let channelPromise: Promise<ChannelClient> | null = null;
 const hasDOMContentLoaded = new DeferredPromise<void>();
 
 if (typeof fin !== 'undefined') {
-    document.addEventListener('DOMContentLoaded', () => {
-        hasDOMContentLoaded.resolve();
-    });
     if (getServiceIdentity().name !== fin.Window.me.name && getServiceIdentity().uuid !== fin.Window.me.uuid) {
         getServicePromise();
 
@@ -61,6 +58,10 @@ if (typeof fin !== 'undefined') {
             }
         });
     }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        hasDOMContentLoaded.resolve();
+    });
 }
 
 export async function getServicePromise(): Promise<ChannelClient> {

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -50,10 +50,7 @@ let hasDisconnectListener = false;
 let reconnect = false;
 
 if (typeof fin !== 'undefined') {
-    if (getServiceIdentity().name !== fin.Window.me.name && getServiceIdentity().uuid !== fin.Window.me.uuid) {
-        console.log('Start');
-        getServicePromise();
-    }
+    getServicePromise();
 
     document.addEventListener('DOMContentLoaded', () => {
         hasDOMContentLoaded.resolve();
@@ -63,7 +60,6 @@ if (typeof fin !== 'undefined') {
 export async function getServicePromise(): Promise<ChannelClient> {
     await hasDOMContentLoaded.promise;
     if (!channelPromise) {
-        console.log('No channel available');
         if (typeof fin === 'undefined') {
             channelPromise = Promise.reject(new Error('fin is not defined. The openfin-fdc3 module is only intended for use in an OpenFin application.'));
         } else {

--- a/src/client/contextChannels.ts
+++ b/src/client/contextChannels.ts
@@ -573,7 +573,6 @@ function deserializeChannelChangedEvent(eventTransport: Transport<ChannelChanged
     const channel = eventTransport.channel ? getChannelObject(eventTransport.channel) : null;
     const previousChannel = eventTransport.previousChannel ? getChannelObject(eventTransport.previousChannel) : null;
 
-    console.log(eventTransport);
     if (fin.Window.me.name === identity.name && fin.Window.me.uuid === identity.uuid) {
         currentChannel = channel;
     }
@@ -622,7 +621,6 @@ function initialize(): Promise<void> {
 async function rehydrate(): Promise<void> {
     let channelToJoin: DefaultChannel | SystemChannel | AppChannel | null = currentChannel;
     // Check if the client reloaded and was already in a channel
-    console.log('Current channel', currentChannel);
     if (!channelToJoin) {
         const previousChannel = await getCurrentChannel();
         channelToJoin = previousChannel ? previousChannel : defaultChannel;
@@ -633,5 +631,4 @@ async function rehydrate(): Promise<void> {
     await channelToJoin.join();
     await Promise.all(channelContextListeners.map(({channel}) => tryServiceDispatch(APIFromClientTopic.CHANNEL_ADD_CONTEXT_LISTENER, {id: channel.id})));
     currentChannel = channelToJoin;
-    console.log('Rehydrate', currentChannel);
 }

--- a/src/client/contextChannels.ts
+++ b/src/client/contextChannels.ts
@@ -617,7 +617,6 @@ function initialize(): Promise<void> {
 
 async function rehydrate(): Promise<void> {
     let channelToJoin: Channel = currentChannel || defaultChannel;
-    // Check if the client reloaded and was already in a channel
     if (channelToJoin.type === 'app') {
         channelToJoin = await getOrCreateAppChannel(channelToJoin.name);
     }

--- a/src/client/contextChannels.ts
+++ b/src/client/contextChannels.ts
@@ -24,7 +24,7 @@ import {Identity} from 'openfin/_v2/main';
 
 import {parseIdentity, parseContext, validateEnvironment, parseChannelId, parseAppChannelName} from './validation';
 import {tryServiceDispatch, getEventRouter, getServicePromise} from './connection';
-import {APIFromClientTopic, ChannelTransport, APIToClientTopic, ChannelReceiveContextPayload, SystemChannelTransport, ChannelEvents, AppChannelTransport, invokeListeners, getServiceIdentity, onReconnect} from './internal';
+import {APIFromClientTopic, ChannelTransport, APIToClientTopic, ChannelReceiveContextPayload, SystemChannelTransport, ChannelEvents, AppChannelTransport, invokeListeners, onReconnect} from './internal';
 import {Context} from './context';
 import {ContextListener} from './main';
 import {Transport} from './EventRouter';
@@ -581,21 +581,19 @@ function deserializeChannelChangedEvent(eventTransport: Transport<ChannelChanged
 }
 
 if (typeof fin !== 'undefined') {
-    if (getServiceIdentity().name !== fin.Window.me.name && getServiceIdentity().uuid !== fin.Window.me.uuid) {
-        const eventHandler = getEventRouter();
-        eventHandler.registerEmitterProvider('channel', (channelId: ChannelId) => {
-            return channelEventEmitters[channelId];
-        });
+    const eventHandler = getEventRouter();
+    eventHandler.registerEmitterProvider('channel', (channelId: ChannelId) => {
+        return channelEventEmitters[channelId];
+    });
 
-        eventHandler.registerDeserializer('channel-changed', deserializeChannelChangedEvent);
-        eventHandler.registerDeserializer('window-added', deserializeWindowAddedEvent);
-        eventHandler.registerDeserializer('window-removed', deserializeWindowRemovedEvent);
-        onReconnect.add(async () => {
-            await initialize();
-            await rehydrate();
-        });
-        initialize();
-    }
+    eventHandler.registerDeserializer('channel-changed', deserializeChannelChangedEvent);
+    eventHandler.registerDeserializer('window-added', deserializeWindowAddedEvent);
+    eventHandler.registerDeserializer('window-removed', deserializeWindowRemovedEvent);
+    onReconnect.add(async () => {
+        await initialize();
+        await rehydrate();
+    });
+    initialize();
 }
 
 function initialize(): Promise<void> {

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -351,3 +351,13 @@ export function setServiceIdentity(uuid: string) {
 export function getServiceIdentity(): Identity {
     return serviceIdentity;
 }
+
+export function registerOnChannelConnect(fn: () => void): void {
+    fin.InterApplicationBus.Channel.onChannelConnect((event: OpenFinChannelConnectionEvent) => {
+        const {uuid, name, channelName} = event;
+        if (uuid === getServiceIdentity().uuid && name === getServiceIdentity().name && channelName === getServiceChannel()) {
+            console.info('Reconnected FDC3 service');
+            fn();
+        }
+    });
+}

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -243,6 +243,16 @@ export interface ChannelReceiveContextPayload {
     context: Context;
 }
 
+export interface OpenFinChannelConnectionEvent {
+    channelId: string;
+    channelName: string;
+    isExternal: boolean;
+    name: string;
+    topic: string;
+    type: string;
+    uuid: string;
+}
+
 /**
  * Invokes an array of listeners with a given context, allowing us to apply consistent error handling. Will throw an error if > 0 listeners are given, and all
  * fail. Otherwise the first *defined* value returned is returned, or undefined is no defined values are returned.

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -9,6 +9,7 @@
  * This file is excluded from the public-facing TypeScript documentation.
  */
 import {Identity} from 'openfin/_v2/main';
+import {Signal} from 'openfin-service-signal';
 
 import {AppName} from './directory';
 import {AppIntent, Context, IntentResolution, Listener} from './main';
@@ -27,6 +28,11 @@ const serviceIdentity: Identity = {
  * Name of the IAB channel use to communicate between client and provider
  */
 let serviceChannel: string = 'of-fdc3-service-v1';
+
+/**
+ * Event fired when the channel to the provider has been re-established.
+ */
+export const onReconnect = new Signal();
 
 /**
  * Enum containing all and only actions that the provider can accept.
@@ -350,14 +356,4 @@ export function setServiceIdentity(uuid: string) {
 }
 export function getServiceIdentity(): Identity {
     return serviceIdentity;
-}
-
-export function registerOnChannelConnect(fn: () => void): void {
-    fin.InterApplicationBus.Channel.onChannelConnect((event: OpenFinChannelConnectionEvent) => {
-        const {uuid, name, channelName} = event;
-        if (uuid === getServiceIdentity().uuid && name === getServiceIdentity().name && channelName === getServiceChannel()) {
-            console.info('Reconnected FDC3 service');
-            fn();
-        }
-    });
 }

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -249,16 +249,6 @@ export interface ChannelReceiveContextPayload {
     context: Context;
 }
 
-export interface OpenFinChannelConnectionEvent {
-    channelId: string;
-    channelName: string;
-    isExternal: boolean;
-    name: string;
-    topic: string;
-    type: string;
-    uuid: string;
-}
-
 /**
  * Invokes an array of listeners with a given context, allowing us to apply consistent error handling. Will throw an error if > 0 listeners are given, and all
  * fail. Otherwise the first *defined* value returned is returned, or undefined is no defined values are returned.

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -348,7 +348,6 @@ export function addContextListener(handler: (context: Context) => void): Context
     const listener: ContextListener = {
         handler,
         unsubscribe: () => {
-            console.log('Unsubscribed', handler);
             const index: number = contextListeners.indexOf(listener);
 
             if (index >= 0) {

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -8,7 +8,7 @@
 import {tryServiceDispatch, getServicePromise, getEventRouter, eventEmitter} from './connection';
 import {Context} from './context';
 import {Application, AppName} from './directory';
-import {APIFromClientTopic, APIToClientTopic, RaiseIntentPayload, ReceiveContextPayload, MainEvents, Events, invokeListeners, getServiceIdentity, onReconnect} from './internal';
+import {APIFromClientTopic, APIToClientTopic, RaiseIntentPayload, ReceiveContextPayload, MainEvents, Events, invokeListeners, onReconnect} from './internal';
 import {ChannelChangedEvent, ChannelContextListener} from './contextChannels';
 import {parseContext, validateEnvironment} from './validation';
 import {Transport, Targeted} from './EventRouter';
@@ -417,17 +417,15 @@ function hasIntentListener(intent: string): boolean {
 }
 
 if (typeof fin !== 'undefined') {
-    if (getServiceIdentity().name !== fin.Window.me.name && getServiceIdentity().uuid !== fin.Window.me.uuid) {
-        const eventHandler = getEventRouter();
-        eventHandler.registerEmitterProvider('main', () => eventEmitter);
-        onReconnect.add(async () => {
-            await initialize();
-            await rehydrate();
-        });
-        setImmediate(() => {
-            initialize();
-        });
-    }
+    const eventHandler = getEventRouter();
+    eventHandler.registerEmitterProvider('main', () => eventEmitter);
+    onReconnect.add(async () => {
+        await initialize();
+        await rehydrate();
+    });
+    setImmediate(() => {
+        initialize();
+    });
 }
 
 async function initialize(): Promise<void> {

--- a/src/demo/index.tsx
+++ b/src/demo/index.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
+import * as fdc3 from '../client/main';
+
 import {BlotterApp} from './apps/BlotterApp';
 import {ChartsApp} from './apps/ChartsApp';
 import {ContactsApp} from './apps/ContactsApp';
 import {DialerApp} from './apps/DialerApp';
 import {LauncherApp} from './apps/LauncherApp';
 import {NewsApp} from './apps/NewsApp';
+
+Object.assign(window, {fdc3});
 
 /*
  * This file defines the entry point for all of the applications in this project. This "bootstrap" is intended to allow

--- a/test/demo/contextChannels/join.inttest.ts
+++ b/test/demo/contextChannels/join.inttest.ts
@@ -7,6 +7,7 @@ import {RemoteChannel, RemoteChannelEventListener} from '../utils/RemoteChannel'
 import {setupTeardown, setupOpenDirectoryAppBookends, setupStartNonDirectoryAppBookends, quitApps, startNonDirectoryApp, startDirectoryApp, reloadProvider} from '../utils/common';
 import {fakeAppChannelName, createFakeContext} from '../utils/fakes';
 import {TestWindowContext} from '../utils/ofPuppeteer';
+import {delay} from '../utils/delay';
 
 /*
  * Tests simple behaviour of Channel.getMembers() and the channel-changed and Channel events, before testing how they and getCurrentChannel()
@@ -574,5 +575,13 @@ describe('When the provider is reloaded', () => {
         await reloadProvider();
         await expect(fdc3Remote.getCurrentChannel(testAppNotInDirectory1)).resolves.toHaveProperty('channel', greenChannel.channel);
         await expect(greenChannel.getMembers()).resolves.toEqual([{uuid: testAppNotInDirectory1.uuid, name: testAppNotInDirectory1.name}]);
+        await reloadProvider();
+        await expect(fdc3Remote.getCurrentChannel(testAppNotInDirectory1)).resolves.toHaveProperty('channel', greenChannel.channel);
+        await expect(greenChannel.getMembers()).resolves.toEqual([{uuid: testAppNotInDirectory1.uuid, name: testAppNotInDirectory1.name}]);
+        await reloadProvider();
+        await expect(fdc3Remote.getCurrentChannel(testAppNotInDirectory1)).resolves.toHaveProperty('channel', greenChannel.channel);
+        await expect(greenChannel.getMembers()).resolves.toEqual([{uuid: testAppNotInDirectory1.uuid, name: testAppNotInDirectory1.name}]);
+
+        await delay(1000);
     });
 });

--- a/test/demo/contextChannels/join.inttest.ts
+++ b/test/demo/contextChannels/join.inttest.ts
@@ -7,7 +7,6 @@ import {RemoteChannel, RemoteChannelEventListener} from '../utils/RemoteChannel'
 import {setupTeardown, setupOpenDirectoryAppBookends, setupStartNonDirectoryAppBookends, quitApps, startNonDirectoryApp, startDirectoryApp, reloadProvider} from '../utils/common';
 import {fakeAppChannelName, createFakeContext} from '../utils/fakes';
 import {TestWindowContext} from '../utils/ofPuppeteer';
-import {delay} from '../utils/delay';
 
 /*
  * Tests simple behaviour of Channel.getMembers() and the channel-changed and Channel events, before testing how they and getCurrentChannel()
@@ -572,16 +571,11 @@ describe('When the provider is reloaded', () => {
         const greenChannel = await fdc3Remote.getChannelById(testAppNotInDirectory1, 'green');
         await greenChannel.join();
 
-        await reloadProvider();
-        await expect(fdc3Remote.getCurrentChannel(testAppNotInDirectory1)).resolves.toHaveProperty('channel', greenChannel.channel);
-        await expect(greenChannel.getMembers()).resolves.toEqual([{uuid: testAppNotInDirectory1.uuid, name: testAppNotInDirectory1.name}]);
-        await reloadProvider();
-        await expect(fdc3Remote.getCurrentChannel(testAppNotInDirectory1)).resolves.toHaveProperty('channel', greenChannel.channel);
-        await expect(greenChannel.getMembers()).resolves.toEqual([{uuid: testAppNotInDirectory1.uuid, name: testAppNotInDirectory1.name}]);
-        await reloadProvider();
-        await expect(fdc3Remote.getCurrentChannel(testAppNotInDirectory1)).resolves.toHaveProperty('channel', greenChannel.channel);
-        await expect(greenChannel.getMembers()).resolves.toEqual([{uuid: testAppNotInDirectory1.uuid, name: testAppNotInDirectory1.name}]);
+        for (let i = 0; i < 4; i++) {
+            await reloadProvider();
+        }
 
-        await delay(1000);
+        await expect(fdc3Remote.getCurrentChannel(testAppNotInDirectory1)).resolves.toHaveProperty('channel', greenChannel.channel);
+        await expect(greenChannel.getMembers()).resolves.toEqual([{uuid: testAppNotInDirectory1.uuid, name: testAppNotInDirectory1.name}]);
     });
 });

--- a/test/demo/contextChannels/join.inttest.ts
+++ b/test/demo/contextChannels/join.inttest.ts
@@ -564,7 +564,7 @@ describe('When using a non-directory app', () => {
     });
 });
 
-describe.only('When the provider is reloaded', () => {
+describe('When the provider is reloaded', () => {
     setupStartNonDirectoryAppBookends(testAppNotInDirectory1);
 
     test('The client rejoins the channel it was previously in', async () => {

--- a/test/demo/contextChannels/join.inttest.ts
+++ b/test/demo/contextChannels/join.inttest.ts
@@ -571,6 +571,8 @@ describe('When the provider is reloaded', () => {
         const greenChannel = await fdc3Remote.getChannelById(testAppNotInDirectory1, 'green');
         await greenChannel.join();
 
+        // Reload multiple times to confirm that the client reconnected and joins the correct channel
+        // If this fails the test app will be in the default channel and not green.
         for (let i = 0; i < 4; i++) {
             await reloadProvider();
         }

--- a/test/demo/contextListener.inttest.ts
+++ b/test/demo/contextListener.inttest.ts
@@ -200,7 +200,7 @@ window, the listener is triggered exactly once with the correct context', async 
             listener = await fdc3Remote.addContextListener(testAppInDirectory1);
         });
 
-        test('Contexts listeners are readded and contexts are recieved', async () => {
+        test('Contexts listeners are readded and contexts are received', async () => {
             await reloadProvider();
             await fdc3Remote.broadcast(testManagerIdentity, validContext);
             await expect(listener).toHaveReceivedContexts([validContext]);

--- a/test/demo/contextListener.inttest.ts
+++ b/test/demo/contextListener.inttest.ts
@@ -2,7 +2,7 @@ import 'jest';
 import {OrganizationContext} from '../../src/client/main';
 
 import * as fdc3Remote from './utils/fdc3RemoteExecution';
-import {setupTeardown, setupOpenDirectoryAppBookends} from './utils/common';
+import {setupTeardown, setupOpenDirectoryAppBookends, reloadProvider} from './utils/common';
 import {testManagerIdentity, testAppInDirectory1, testAppUrl} from './constants';
 import {delay, Duration} from './utils/delay';
 
@@ -189,6 +189,21 @@ window, the listener is triggered exactly once with the correct context', async 
 
             // Window on the same app as the one broadcasting DOES receive context
             await expect(testAppMainWindowListener).toHaveReceivedContexts([validContext]);
+        });
+    });
+
+    describe('When the provider is reloaded', () => {
+        let listener: fdc3Remote.RemoteContextListener;
+        setupOpenDirectoryAppBookends(testAppInDirectory1);
+
+        beforeEach(async () => {
+            listener = await fdc3Remote.addContextListener(testAppInDirectory1);
+        });
+
+        test('Contexts listeners are readded and contexts are recieved', async () => {
+            await reloadProvider();
+            await fdc3Remote.broadcast(testManagerIdentity, validContext);
+            await expect(listener).toHaveReceivedContexts([validContext]);
         });
     });
 });

--- a/test/demo/open.inttest.ts
+++ b/test/demo/open.inttest.ts
@@ -256,7 +256,7 @@ the promise resolves', async () => {
                 await expect(preregisteredListener).toHaveReceivedContexts([validContext]);
             });
 
-            test('When the running app has a listener that throws an error, the promise rejects with an FDC3 error', async () => {
+            test.only('When the running app has a listener that throws an error, the promise rejects with an FDC3 error', async () => {
                 // Remove the pre-registered listener
                 const preregisteredListener = await fdc3Remote.getRemoteContextListener(testAppWithPreregisteredListeners1);
                 await preregisteredListener.unsubscribe();
@@ -268,9 +268,9 @@ the promise resolves', async () => {
                     });
                 });
 
+                await delay(30000);
                 // From the launcher app, call fdc3.open with a valid name and context
                 const promise = allowReject(open(testAppWithPreregisteredListeners1.name, validContext));
-
                 // Check the promise rejects as expected
                 await expect(promise).toThrowFDC3Error(
                     SendContextError.HandlerError,

--- a/test/demo/open.inttest.ts
+++ b/test/demo/open.inttest.ts
@@ -256,7 +256,7 @@ the promise resolves', async () => {
                 await expect(preregisteredListener).toHaveReceivedContexts([validContext]);
             });
 
-            test.only('When the running app has a listener that throws an error, the promise rejects with an FDC3 error', async () => {
+            test('When the running app has a listener that throws an error, the promise rejects with an FDC3 error', async () => {
                 // Remove the pre-registered listener
                 const preregisteredListener = await fdc3Remote.getRemoteContextListener(testAppWithPreregisteredListeners1);
                 await preregisteredListener.unsubscribe();
@@ -268,7 +268,6 @@ the promise resolves', async () => {
                     });
                 });
 
-                await delay(30000);
                 // From the launcher app, call fdc3.open with a valid name and context
                 const promise = allowReject(open(testAppWithPreregisteredListeners1.name, validContext));
                 // Check the promise rejects as expected

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -7,7 +7,7 @@ import {ResolveError, ApplicationError, SendContextError} from '../../../src/cli
 import {fin} from '../utils/fin';
 import * as fdc3Remote from '../utils/fdc3RemoteExecution';
 import {delay, Duration} from '../utils/delay';
-import {TestAppData, DirectoryTestAppData, setupOpenDirectoryAppBookends, setupStartNonDirectoryAppBookends, setupTeardown, setupQuitAppAfterEach, waitForAppToBeRunning} from '../utils/common';
+import {TestAppData, DirectoryTestAppData, setupOpenDirectoryAppBookends, setupStartNonDirectoryAppBookends, setupTeardown, setupQuitAppAfterEach, waitForAppToBeRunning, reloadProvider} from '../utils/common';
 import {appStartupTime, testManagerIdentity, testAppInDirectory1, testAppNotInDirectory1, testAppWithPreregisteredListeners1, testAppNotInDirectoryNotFdc3, testAppUrl} from '../constants';
 import {Intent, IntentType} from '../../../src/provider/intents';
 import {TestWindowContext} from '../utils/ofPuppeteer';
@@ -173,6 +173,26 @@ listener to be added', async () => {
             setupStartNonDirectoryAppBookends(testAppNotInDirectory1);
             setupCommonRunningAppTests(testAppNotInDirectory1);
         });
+    });
+});
+
+describe('When reloading the provider', () => {
+    setupOpenDirectoryAppBookends(testAppWithPreregisteredListeners1);
+
+    test('Apps with a preregistered intent listener recieve intents', async () => {
+        await reloadProvider();
+
+        await raiseIntent(preregisteredIntent, testAppWithPreregisteredListeners1);
+        const listener = await fdc3Remote.getRemoteIntentListener(testAppWithPreregisteredListeners1, preregisteredIntent.type);
+        await expect(listener).toHaveReceivedContexts([preregisteredIntent.context]);
+    });
+
+    test('Apps that registered an intent listener recieve intents', async () => {
+        const listener = await fdc3Remote.addIntentListener(testAppWithPreregisteredListeners1, validIntent.type);
+        await reloadProvider();
+
+        await raiseIntent(validIntent, testAppWithPreregisteredListeners1);
+        await expect(listener).toHaveReceivedContexts([validIntent.context]);
     });
 });
 

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -179,7 +179,7 @@ listener to be added', async () => {
 describe('When reloading the provider', () => {
     setupOpenDirectoryAppBookends(testAppWithPreregisteredListeners1);
 
-    test('Apps with a preregistered intent listener recieve intents', async () => {
+    test('Apps with a preregistered intent listener receive intents', async () => {
         await reloadProvider();
 
         await raiseIntent(preregisteredIntent, testAppWithPreregisteredListeners1);
@@ -187,7 +187,7 @@ describe('When reloading the provider', () => {
         await expect(listener).toHaveReceivedContexts([preregisteredIntent.context]);
     });
 
-    test('Apps that registered an intent listener recieve intents', async () => {
+    test('Apps that registered an intent listener receive intents', async () => {
         const listener = await fdc3Remote.addIntentListener(testAppWithPreregisteredListeners1, validIntent.type);
         await reloadProvider();
 

--- a/test/demo/utils/common.ts
+++ b/test/demo/utils/common.ts
@@ -40,6 +40,13 @@ export async function quitApps(...apps: Identity[]) {
     await delay(250);
 }
 
+export async function reloadProvider(): Promise<void> {
+    await fdc3Remote.ofBrowser.executeOnWindow(getServiceIdentity(), function (this: ProviderWindow) {
+        this.window.location.reload();
+    });
+    await delay(Duration.PROVIDER_RELOAD);
+}
+
 export async function waitForAppToBeRunning(app: Identity): Promise<void> {
     let timedOut = false;
 
@@ -194,11 +201,4 @@ async function isServiceClear(): Promise<boolean> {
             return true;
         }, testManagerIdentity
     );
-}
-
-export async function reloadProvider(): Promise<void> {
-    await fdc3Remote.ofBrowser.executeOnWindow(getServiceIdentity(), function (this: ProviderWindow) {
-        this.window.location.reload();
-    });
-    await delay(Duration.PROVIDER_RELOAD);
 }

--- a/test/demo/utils/common.ts
+++ b/test/demo/utils/common.ts
@@ -195,3 +195,10 @@ async function isServiceClear(): Promise<boolean> {
         }, testManagerIdentity
     );
 }
+
+export async function reloadProvider(): Promise<void> {
+    await fdc3Remote.ofBrowser.executeOnWindow(SERVICE_IDENTITY, function (this: ProviderWindow) {
+        this.window.location.reload();
+    });
+    await delay(Duration.PAGE_RELOAD);
+}

--- a/test/demo/utils/common.ts
+++ b/test/demo/utils/common.ts
@@ -200,5 +200,5 @@ export async function reloadProvider(): Promise<void> {
     await fdc3Remote.ofBrowser.executeOnWindow(getServiceIdentity(), function (this: ProviderWindow) {
         this.window.location.reload();
     });
-    await delay(Duration.PAGE_RELOAD);
+    await delay(Duration.PROVIDER_RELOAD);
 }

--- a/test/demo/utils/delay.ts
+++ b/test/demo/utils/delay.ts
@@ -9,6 +9,7 @@ export async function delay(duration: number) {
 }
 
 export enum Duration {
+    PROVIDER_RELOAD = 2000,
     PAGE_RELOAD = 500,
     PAGE_NAVIGATE = 500,
     SHORTER_THAN_APP_MATURITY = 2000,

--- a/test/demo/utils/ofPuppeteer.ts
+++ b/test/demo/utils/ofPuppeteer.ts
@@ -70,7 +70,7 @@ export class OFPuppeteerBrowser<WindowContext extends BaseWindowContext = BaseWi
         return this._browser;
     }
 
-    private async getPage(identity: Identity): Promise<Page|undefined> {
+    public async getPage(identity: Identity): Promise<Page|undefined> {
         await this._ready;
         const idString = getIdString(identity);
 

--- a/test/demo/utils/ofPuppeteer.ts
+++ b/test/demo/utils/ofPuppeteer.ts
@@ -70,7 +70,7 @@ export class OFPuppeteerBrowser<WindowContext extends BaseWindowContext = BaseWi
         return this._browser;
     }
 
-    public async getPage(identity: Identity): Promise<Page|undefined> {
+    private async getPage(identity: Identity): Promise<Page|undefined> {
         await this._ready;
         const idString = getIdString(identity);
 


### PR DESCRIPTION
This PR adds reconnect logic to the client so for when the provider reloads or disconnects.

- Await for DOMContentLoaded event before initializing.
- Wait for IAB channel.
- On disconnect rejoin channel.
- Readd context/intent listeners on reconnect.
- Rejoin channels.