### PR TITLE
[SERVICE-877] Closing an application with child windows connected to FDC3 doesn't remove them from the Model

### DIFF
--- a/src/provider/model/FinEnvironment.ts
+++ b/src/provider/model/FinEnvironment.ts
@@ -180,7 +180,6 @@ export class FinEnvironment extends AsyncInit implements Environment {
 
             await Injector.initialized;
             this.deregisterEntity(identity);
-            this.deregisterApplication({uuid: event.uuid});
         };
 
         fin.System.addListener('application-started', async (event: ApplicationEvent<'system', 'application-started'>) => {

--- a/src/provider/model/Model.ts
+++ b/src/provider/model/Model.ts
@@ -327,6 +327,8 @@ export class Model {
         const app = this._liveAppsByUuid[uuid];
 
         if (app) {
+            app.connections.forEach((connection) => this.removeConnection(connection.identity));
+
             app.setClosed();
             delete this._liveAppsByUuid[uuid];
         }

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -170,8 +170,30 @@ listener to be added', async () => {
         });
 
         describe('When the target (which is an ad-hoc app) is running', () => {
+            let listener: fdc3Remote.RemoteIntentListener;
+
             setupStartNonDirectoryAppBookends(testAppNotInDirectory1);
             setupCommonRunningAppTests(testAppNotInDirectory1);
+
+            // This test is in response to a bug where an app would be wrong de-registered if any child window de-registered
+            describe.only('When the target has opened and closed a child window', () => {
+                beforeEach(async () => {
+                    listener = await fdc3Remote.addIntentListener(testAppNotInDirectory1, validIntent.type);
+                    const childIdentity = await fdc3Remote.createFinWindow(testAppNotInDirectory1, {name: 'child-window'});
+
+                    await fin.Window.wrapSync(childIdentity).close();
+                });
+
+                afterEach(async () => {
+                    await listener.unsubscribe();
+                });
+
+                test('When calling raiseIntent from another app the listener is triggered exactly once with the correct context', async () => {
+                    await raiseIntent(validIntent, testAppNotInDirectory1);
+
+                    await expect(listener).toHaveReceivedContexts([validIntent.context]);
+                });
+            });
         });
     });
 });

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -176,7 +176,7 @@ listener to be added', async () => {
             setupCommonRunningAppTests(testAppNotInDirectory1);
 
             // This test is in response to a bug where an app would be wrong de-registered if any child window de-registered
-            describe.only('When the target has opened and closed a child window', () => {
+            describe('When the target has opened and closed a child window', () => {
                 beforeEach(async () => {
                     listener = await fdc3Remote.addIntentListener(testAppNotInDirectory1, validIntent.type);
                     const childIdentity = await fdc3Remote.createFinWindow(testAppNotInDirectory1, {name: 'child-window'});

--- a/test/demo/raiseIntent/withTarget.inttest.ts
+++ b/test/demo/raiseIntent/withTarget.inttest.ts
@@ -175,7 +175,7 @@ listener to be added', async () => {
             setupStartNonDirectoryAppBookends(testAppNotInDirectory1);
             setupCommonRunningAppTests(testAppNotInDirectory1);
 
-            // This test is in response to a bug where an app would be wrong de-registered if any child window de-registered
+            // This test is in response to a bug where an app would be wrongly de-registered if any child window de-registered
             describe('When the target has opened and closed a child window', () => {
                 beforeEach(async () => {
                     listener = await fdc3Remote.addIntentListener(testAppNotInDirectory1, validIntent.type);


### PR DESCRIPTION
This PR
- Ensures when an app is deregistered, all its connections are deregistered
- That we don't prematurely deregister an app when one of its child entities closes