### PR TITLE
[SERVICE-1005] Broadcast Data not received within window that has FDC3 injected via preload script

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -52,7 +52,7 @@ let reconnect = false;
 if (typeof fin !== 'undefined') {
     getServicePromise();
 
-    document.addEventListener('DOMContentLoaded', () => {
+    window.addEventListener('DOMContentLoaded', () => {
         hasDOMContentLoaded.resolve();
     });
 }


### PR DESCRIPTION
Bit of an annoyance, but it looks like runtime has a bug specifically with document.addEventListener('DOMContentLoaded') not firing on first page loads in child windows only. However, window.addEventListener('DOMContentLoaded') works OK.

The difference between the window and document is literally that the window version is just a bubble up from the document event.

https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event