### PR TITLE
[SERVICE-1012] Have application directory default to public directory

### DIFF
--- a/res/provider/config/fdc3-config.schema.json
+++ b/res/provider/config/fdc3-config.schema.json
@@ -132,7 +132,7 @@
             "properties": {
                 "applicationDirectory": {
                     "type": "string",
-                    "default": "",
+                    "default": "https://app-directory.openfin.co/api/v1/apps",
                     "description": "The default location of the application directory"
                 }
             },

--- a/src/demo/apps/LauncherApp.tsx
+++ b/src/demo/apps/LauncherApp.tsx
@@ -46,7 +46,7 @@ export function LauncherApp(): React.ReactElement {
     }, []);
 
     const openApp = async (app: AppLaunchData) => {
-        const id: string = (app.type === 'manifest') ? app.data.appId : app.data.uuid;
+        const id: string = (app.type === 'manifest') ? app.data.name : app.data.uuid;
         const title: string = ((app.type === 'manifest') ? app.data.title : app.data.name) || id;
         console.log(`Opening app ${title}`);
         try {

--- a/test/provider/AppDirectory.unittest.ts
+++ b/test/provider/AppDirectory.unittest.ts
@@ -69,7 +69,7 @@ const mockFetchReturnJson = jest.fn().mockResolvedValue(fakeApps);
 /**
  * Creates a new Application Directory with the specified URL
  */
-async function createAppDirectory(url: string): Promise<void> {
+async function createAppDirectory(url?: string): Promise<void> {
     const configStore: ConfigStoreBinding = {
         config: new Store<ConfigurationObject>(require('../../gen/provider/config/defaults.json')),
         initialized: Promise.resolve()
@@ -106,6 +106,27 @@ beforeEach(() => {
 });
 
 describe('When Fetching Initial Data', () => {
+    describe('And config applicationDirectory is undefined', () => {
+        beforeEach(async () => {
+            await createAppDirectory(undefined);
+        });
+
+        test('The default public application directory is used', async () => {
+            await expect(appDirectory.getAllApps()).resolves.toEqual(fakeApps);
+        });
+    });
+
+    describe('And config applicationDirectory is falsey', () => {
+        beforeEach(async () => {
+            mockFetchReturnJson.mockRejectedValue({});
+            await createAppDirectory('');
+        });
+
+        test('The application directory will be empty', async () => {
+            await expect(appDirectory.getAllApps()).resolves.toEqual([]);
+        });
+    });
+
     describe('And we\'re online', () => {
         beforeEach(async () => {
             await createAppDirectory(DEV_APP_DIRECTORY_URL);


### PR DESCRIPTION
Sets the default directory value to be the openfin public directory, and fixes the demo application to pass in the correct value for the fdc3.open call.