### PR TITLE
[SERVICE-989] Fixed paths within manifest/config files

### DIFF
--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -4,7 +4,7 @@
     "startup_app": {
         "name": "FDC3-Service",
         "description": "OpenFin FDC3 Desktop Service",
-        "url": "https://cdn.openfin.co/services/openfin/fdc3/provider.html",
+        "url": "https://cdn.openfin.co/services/openfin/fdc3/${VERSION}/provider.html",
         "uuid": "fdc3-service",
         "autoShow": true,
         "defaultHeight": 400,

--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -6,7 +6,7 @@
         "description": "OpenFin FDC3 Desktop Service",
         "url": "https://cdn.openfin.co/services/openfin/fdc3/${VERSION}/provider.html",
         "uuid": "fdc3-service",
-        "autoShow": true,
+        "autoShow": false,
         "defaultHeight": 400,
         "defaultWidth": 500
     },

--- a/services.config.json
+++ b/services.config.json
@@ -3,6 +3,6 @@
     "NAME": "fdc3",
     "TITLE": "FDC3",
 
-    "CDN_LOCATION": "https://cdn.openfin.co/services/openfin/fdc3",
+    "CDN_LOCATION": "https://cdn.openfin.co/services/openfin/fdc3/${VERSION}",
     "RUNTIME_INJECTABLE": true
 }


### PR DESCRIPTION
Fixed paths within manifest/config files to point to the correct CDN base location.

I missed this change when bumping to the service-tooling version that included this change: https://github.com/HadoukenIO/service-tooling/pull/127. CDN paths are now constructed using string templating, rather than assuming all projects are versioned (as some, such as os-launchpad, aren't).