### PR TITLE
[N/A] Import tweaks

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -45,19 +45,23 @@ export function getEventRouter(): EventRouter<Events> {
  * Promise to the channel object that allows us to connect to the client
  */
 let channelPromise: Promise<ChannelClient> | null = null;
-const hasDOMContentLoaded = new DeferredPromise<void>();
+const environmentInitialized = new DeferredPromise<void>();
 let hasDisconnectListener = false;
 let reconnect = false;
 
-window.addEventListener('DOMContentLoaded', () => {
-    hasDOMContentLoaded.resolve();
-});
+if (typeof window !== 'undefined') {
+    window.addEventListener('DOMContentLoaded', () => {
+        environmentInitialized.resolve();
+    });
+} else {
+    environmentInitialized.resolve();
+}
 if (typeof fin !== 'undefined') {
     getServicePromise();
 }
 
 export async function getServicePromise(): Promise<ChannelClient> {
-    await hasDOMContentLoaded.promise;
+    await environmentInitialized.promise;
     if (!channelPromise) {
         if (typeof fin === 'undefined') {
             channelPromise = Promise.reject(new Error('fin is not defined. The openfin-fdc3 module is only intended for use in an OpenFin application.'));

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -15,9 +15,8 @@ import {EventEmitter} from 'events';
 
 import {DeferredPromise} from 'openfin-service-async';
 import {ChannelClient} from 'openfin/_v2/api/interappbus/channel/client';
-import {RuntimeInfo} from 'openfin/_v2/api/system/runtime-info';
 
-import {APIFromClientTopic, getServiceChannel, setServiceChannel, getServiceIdentity, setServiceIdentity, APIFromClient, deserializeError, Events, onReconnect} from './internal';
+import {APIFromClientTopic, getServiceChannel, getServiceIdentity, setServiceIdentity, APIFromClient, deserializeError, Events, onReconnect} from './internal';
 import {EventRouter} from './EventRouter';
 
 /**
@@ -67,13 +66,7 @@ export async function getServicePromise(): Promise<ChannelClient> {
             channelPromise = Promise.reject(new Error('fin is not defined. The openfin-fdc3 module is only intended for use in an OpenFin application.'));
         } else {
             channelPromise = new Promise<ChannelClient>(async (resolve, reject) => {
-                // TODO: just use RuntimeInfo once its type is updated from js v2 API
-                const info: RuntimeInfo & {fdc3AppUuid?: string; fdc3ChannelName?: string} = await fin.System.getRuntimeInfo();
-
-                if (info.fdc3AppUuid && info.fdc3ChannelName) {
-                    setServiceIdentity(info.fdc3AppUuid);
-                    setServiceChannel(info.fdc3ChannelName);
-                }
+                await setServiceIdentity();
 
                 if (fin.Window.me.uuid === getServiceIdentity().uuid && fin.Window.me.name === getServiceIdentity().name) {
                     reject(new Error('Trying to connect to provider from provider'));

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -49,12 +49,11 @@ const hasDOMContentLoaded = new DeferredPromise<void>();
 let hasDisconnectListener = false;
 let reconnect = false;
 
+window.addEventListener('DOMContentLoaded', () => {
+    hasDOMContentLoaded.resolve();
+});
 if (typeof fin !== 'undefined') {
     getServicePromise();
-
-    window.addEventListener('DOMContentLoaded', () => {
-        hasDOMContentLoaded.resolve();
-    });
 }
 
 export async function getServicePromise(): Promise<ChannelClient> {

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -48,8 +48,8 @@ const environmentInitialized = new DeferredPromise<void>();
 let hasDisconnectListener = false;
 let reconnect = false;
 
-if (typeof window !== 'undefined') {
-    window.addEventListener('DOMContentLoaded', () => {
+if (typeof document !== 'undefined' && document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
         environmentInitialized.resolve();
     });
 } else {

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -331,12 +331,18 @@ export function getServiceIdentity(): Identity {
     return serviceIdentity;
 }
 
-export async function setServiceIdentity() {
-    const info: RuntimeInfo = await fin.System.getRuntimeInfo();
+export async function setServiceIdentity(runtimeVersion?: string) {
+    if (runtimeVersion === undefined) {
+        const info: RuntimeInfo = await fin.System.getRuntimeInfo();
 
-    if (info.fdc3AppUuid && info.fdc3ChannelName) {
-        serviceIdentity.uuid = info.fdc3AppUuid;
-        serviceIdentity.name = info.fdc3AppUuid;
-        serviceChannel = info.fdc3ChannelName;
+        if (info.fdc3AppUuid && info.fdc3ChannelName) {
+            serviceIdentity.uuid = info.fdc3AppUuid;
+            serviceIdentity.name = info.fdc3AppUuid;
+            serviceChannel = info.fdc3ChannelName;
+        }
+    } else if (runtimeVersion) {
+        serviceIdentity.uuid += `-${runtimeVersion}`;
+        serviceIdentity.name += `-${runtimeVersion}`;
+        serviceChannel += `-${runtimeVersion}`;
     }
 }

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -9,6 +9,7 @@
  * This file is excluded from the public-facing TypeScript documentation.
  */
 import {Identity} from 'openfin/_v2/main';
+import {RuntimeInfo} from 'openfin/_v2/api/system/runtime-info';
 import {Signal} from 'openfin-service-signal';
 
 import {AppName} from './directory';
@@ -323,17 +324,19 @@ export function deserializeError(error: Error): Error | FDC3Error {
     return error;
 }
 
-export function setServiceChannel(channelName: string) {
-    serviceChannel = channelName;
-}
 export function getServiceChannel(): string {
     return serviceChannel;
 }
-
-export function setServiceIdentity(uuid: string) {
-    serviceIdentity.uuid = uuid;
-    serviceIdentity.name = uuid;
-}
 export function getServiceIdentity(): Identity {
     return serviceIdentity;
+}
+
+export async function setServiceIdentity() {
+    const info: RuntimeInfo = await fin.System.getRuntimeInfo();
+
+    if (info.fdc3AppUuid && info.fdc3ChannelName) {
+        serviceIdentity.uuid = info.fdc3AppUuid;
+        serviceIdentity.name = info.fdc3AppUuid;
+        serviceChannel = info.fdc3ChannelName;
+    }
 }

--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -4,7 +4,7 @@ import {ChannelProvider} from 'openfin/_v2/api/interappbus/channel/provider';
 import {Identity} from 'openfin/_v2/main';
 import {Signal} from 'openfin-service-signal';
 
-import {getServiceChannel, serializeError} from '../client/internal';
+import {getServiceChannel, serializeError, setServiceIdentity} from '../client/internal';
 
 import {getId} from './utils/getId';
 import {SemVer} from './utils/SemVer';
@@ -112,6 +112,7 @@ export class APIHandler<T extends Enum> {
     }
 
     public async registerListeners<S extends APISpecification<T>>(actionHandlerMap: APIImplementation<T, S>): Promise<void> {
+        await setServiceIdentity();
         this._providerChannel = await fin.InterApplicationBus.Channel.create(getServiceChannel());
 
         this._providerChannel.onConnection(this.onConnectionHandler.bind(this));

--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -4,7 +4,7 @@ import {ChannelProvider} from 'openfin/_v2/api/interappbus/channel/provider';
 import {Identity} from 'openfin/_v2/main';
 import {Signal} from 'openfin-service-signal';
 
-import {getServiceChannel, serializeError, setServiceIdentity} from '../client/internal';
+import {getServiceChannel, serializeError} from '../client/internal';
 
 import {getId} from './utils/getId';
 import {SemVer} from './utils/SemVer';
@@ -112,7 +112,6 @@ export class APIHandler<T extends Enum> {
     }
 
     public async registerListeners<S extends APISpecification<T>>(actionHandlerMap: APIImplementation<T, S>): Promise<void> {
-        await setServiceIdentity();
         this._providerChannel = await fin.InterApplicationBus.Channel.create(getServiceChannel());
 
         this._providerChannel.onConnection(this.onConnectionHandler.bind(this));

--- a/src/provider/controller/ChannelHandler.ts
+++ b/src/provider/controller/ChannelHandler.ts
@@ -3,7 +3,8 @@ import {Signal, Aggregators} from 'openfin-service-signal';
 
 import {Model} from '../model/Model';
 import {Inject} from '../common/Injectables';
-import {ChannelId, FDC3Error, ChannelError, Context} from '../../client/main';
+import {ChannelId, Context} from '../../client/main';
+import {FDC3Error, ChannelError} from '../../client/errors';
 import {SystemContextChannel, ContextChannel, AppContextChannel} from '../model/ContextChannel';
 import {AppConnection} from '../model/AppConnection';
 import {ChannelEvents} from '../../client/internal';

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -4,7 +4,7 @@ import {Identity} from 'openfin/_v2/main';
 import {ProviderIdentity} from 'openfin/_v2/api/interappbus/channel/channel';
 
 import {FDC3Error, ConnectionError, ApplicationError, SendContextError} from '../client/errors';
-import {RaiseIntentPayload, APIFromClientTopic, OpenPayload, FindIntentPayload, FindIntentsByContextPayload, BroadcastPayload, APIFromClient, AddIntentListenerPayload, RemoveIntentListenerPayload, GetSystemChannelsPayload, GetCurrentChannelPayload, ChannelGetMembersPayload, ChannelJoinPayload, GetChannelByIdPayload, ChannelBroadcastPayload, ChannelGetCurrentContextPayload, ChannelAddContextListenerPayload, ChannelRemoveContextListenerPayload, ChannelAddEventListenerPayload, ChannelRemoveEventListenerPayload, GetOrCreateAppChannelPayload, AddContextListenerPayload, RemoveContextListenerPayload} from '../client/internal';
+import {RaiseIntentPayload, APIFromClientTopic, OpenPayload, FindIntentPayload, FindIntentsByContextPayload, BroadcastPayload, APIFromClient, AddIntentListenerPayload, RemoveIntentListenerPayload, GetSystemChannelsPayload, GetCurrentChannelPayload, ChannelGetMembersPayload, ChannelJoinPayload, GetChannelByIdPayload, ChannelBroadcastPayload, ChannelGetCurrentContextPayload, ChannelAddContextListenerPayload, ChannelRemoveContextListenerPayload, ChannelAddEventListenerPayload, ChannelRemoveEventListenerPayload, GetOrCreateAppChannelPayload, AddContextListenerPayload, RemoveContextListenerPayload, setServiceIdentity} from '../client/internal';
 import {AppIntent, IntentResolution, Application, Context, ChannelTransport, SystemChannelTransport, AppChannelTransport} from '../client/main';
 import {parseIdentity, parseContext, parseChannelId, parseAppChannelName} from '../client/validation';
 
@@ -72,6 +72,9 @@ export class Main {
             intentHandler: this._intentHandler,
             model: this._model
         });
+
+        // Fetch our identity, and derive the name of the IAB channel
+        await setServiceIdentity();
 
         // Wait for creation of any injected components that require async initialization
         await Injector.init();

--- a/test/demo/utils/integrationSetupAfterEnv.js
+++ b/test/demo/utils/integrationSetupAfterEnv.js
@@ -9,5 +9,5 @@ if (args && args.asar) {
     const runtime = args.runtime || manifest.runtime.version;
 
     // Set service identity, in a place that is accesssible to tests
-    setServiceIdentity(`fdc3-service-${runtime}`);
+    setServiceIdentity(runtime);
 }


### PR DESCRIPTION
Two small tweaks/fixes:
* Prevented harmless-but-annoying "Trying to connect to provider from provider" errors in provider console, which happens when the provider ends up referencing `connection.ts` in a "Javascript-y" way.
* Fixed the detection of non-OpenFin environments so that calls will reject with error, rather than hang indefinitely. This was because the client was waiting on a `DOMContentLoaded` event, but that listener wasn't being added.