### PR TITLE
[N/A] Allow script-based client to be used as a preload script in child windows

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -48,8 +48,8 @@ const environmentInitialized = new DeferredPromise<void>();
 let hasDisconnectListener = false;
 let reconnect = false;
 
-if (typeof document !== 'undefined' && document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => {
+if (typeof window !== 'undefined' && typeof document !== 'undefined' && document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', () => {
         environmentInitialized.resolve();
     });
 } else {


### PR DESCRIPTION
This is effectively a re-submit of SERVICE-1005/#212, which I managed to undo when doing some pre-release bug fixes.